### PR TITLE
Release alpha 0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.0.9] - XXX
+- Add support for calling `len()` on an inventory to find the number of radionuclides it contains.
+- In icrp107_dataset.ipynb, clarify that ICRP-107 does not contain data on spontaneous fission outcomes.
+- ReadMe and Docs updates (large update of the theory docpage).
+
 ## [0.0.8] - 2020-10-13
 - Add methods to `Radionuclide` class for fetching branching fractions and decay modes.
 - Add methods to `DecayData` class for fetching half-lives, branching fractions and decay modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Changelog
 
-## [0.0.9] - XXX
-- Add support for calling `len()` on an inventory to find the number of radionuclides it contains.
+## [0.0.9] - 2020-11-24
+- Add support for using `Radionuclide` objects in place of radionuclide strings for `Inventory`
+constructor, `add()` and `remove()` methods.
+- Add `Radionuclide` `__hash__()` method (needed for above change).
+- Add `half_lives()`, `progeny()`, `branching_fractions()` and `decay_modes()` methods to
+`Inventory`.
 - Add type hinting.
-- Code refactoring.
-- In icrp107_dataset.ipynb, clarify that ICRP-107 does not contain data on spontaneous fission outcomes.
-- ReadMe and Docs updates (large update of the theory docpage).
+- Add support for calling `len()` on an `Inventory` to find the number of radionuclides it
+contains.
+- Add support for `==` and `!=` operators with `DecayData`, `Radionuclide` and `Inventory`
+instances.
+- Add support for `'ps'` (picoseconds) time unit.
+- Code refactoring. `Radionuclide` and `Inventory` classes moved into separate files.
+- In icrp107_dataset.ipynb, clarify that ICRP-107 does not contain data on spontaneous fission
+outcomes.
+- ReadMe and Docs updates (mainly updates of the theory and tutorial docpages).
 
 ## [0.0.8] - 2020-10-13
 - Add methods to `Radionuclide` class for fetching branching fractions and decay modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.0.9] - XXX
 - Add support for calling `len()` on an inventory to find the number of radionuclides it contains.
+- Add type hinting.
 - In icrp107_dataset.ipynb, clarify that ICRP-107 does not contain data on spontaneous fission outcomes.
 - ReadMe and Docs updates (large update of the theory docpage).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.0.9] - XXX
 - Add support for calling `len()` on an inventory to find the number of radionuclides it contains.
 - Add type hinting.
+- Code refactoring.
 - In icrp107_dataset.ipynb, clarify that ICRP-107 does not contain data on spontaneous fission outcomes.
 - ReadMe and Docs updates (large update of the theory docpage).
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ queried directly as follows:
 >>> rd.DEFAULTDATA.branching_fraction('Cs-137', 'Ba-137m')
 0.94399
 >>> rd.DEFAULTDATA.decay_mode('Cs-137', 'Ba-137m')
-'É¿-'
+'Œ≤-'
+```
 
 ## How radioactivedecay works
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ By default ``radioactivedecay`` uses decay data from
 
 The [notebooks folder](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks)
 in the GitHub repository contains Jupyter Notebooks for creating the processed
-decay datasets that are read in by radioactive decay, e.g.
+decay datasets that are read in by ``radioactivedecay``, e.g.
 [ICRP 107](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/icrp107_dataset/icrp107_dataset.ipynb).
 It also contains some comparisons of decay calculations against the
 [PyNE](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/comparisons/pyne/rd_pyne_truncated_compare.ipynb)

--- a/README.md
+++ b/README.md
@@ -29,13 +29,11 @@ $ pip install radioactivedecay
 ## Usage
 
 ### Decay calculations
-Create an inventory of radionuclides and decay it as follows:
+Create an `Inventory` of radionuclides and decay it as follows:
 
 ```pycon
 >>> import radioactivedecay as rd
 >>> inv = rd.Inventory({'I-123': 1.0, 'Tc-99m': 2.0})
->>> inv.contents
-{'I-123': 1.0, 'Tc-99m': 2.0}
 >>> inv = inv.decay(20.0, 'h')
 >>> inv.contents
 {'I-123': 0.35180331802323694,
@@ -74,7 +72,7 @@ the program.
 decay information for individual radionuclides.
 
 ```pycon
->>> nuc = rd.Radionuclide('I123')
+>>> nuc = rd.Radionuclide('I-123')
 >>> nuc.half_life('d')
 13.27
 >>> nuc.progeny()
@@ -90,6 +88,18 @@ are <sup>123</sup>Te and <sup>123m</sup>Te, with branching fractions 0.99996
 and 4.442e-05 respectively. Both of the decay modes occur via electron capture
 (EC).
 
+The default decay dataset in ``radioactivedecay``  is ICRP-107. Its data can be
+queried directly as follows:
+
+```pycon
+>>> rd.DEFAULTDATA.dataset
+'icrp107'
+>>> rd.DEFAULTDATA.half_life('Cs-137', 'y')
+30.1671
+>>> rd.DEFAULTDATA.branching_fraction('Cs-137', 'Ba-137m')
+0.94399
+>>> rd.DEFAULTDATA.decay_mode('Cs-137', 'Ba-137m')
+'É¿-'
 
 ## How radioactivedecay works
 
@@ -143,4 +153,5 @@ Special thanks to
 * [Center for Computational Science & e-Systems](https://ccse.jaea.go.jp/index_eng.html),
 Japan Atomic Energy Agency
 * [Kenny McKee](https://github.com/Rolleroo)
+
 for their help and support to this project.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ API
    :caption: Modules:
    
    decaydata
-   decayfunctions
+   inventory
+   radionuclide
    utils
    

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2020, Alex Malins"
 author = "Alex Malins"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.8"
+release = "0.0.9"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/decayfunctions.rst
+++ b/docs/source/decayfunctions.rst
@@ -1,6 +1,0 @@
-decayfunctions
-==============
-
-.. automodule:: radioactivedecay.decayfunctions
-   :members:
-   

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,7 +18,7 @@ covers 1252 radionuclides of 97 elements.
    
    overview
    installation
-   usage
+   tutorial
    theory
    api
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,10 +4,10 @@ Installation
 Prerequisites
 -------------
 
-``radioactivedecay`` requires a Python 3.6+ installation and depends on the
-`NumPy <https://numpy.org/>`_ and `SciPy <https://www.scipy.org/index.html>`_
-packages. These can be installed from `python.org <https://www.python.org/>`_
-and `PyPI <https://pypi.org/>`_, or via a package manager such as `Anaconda
+``radioactivedecay`` requires Python 3.6+ and the `NumPy <https://numpy.org/>`_
+and `SciPy <https://www.scipy.org/index.html>`_ packages. These can be
+installed from `python.org <https://www.python.org/>`_ and `PyPI
+<https://pypi.org/>`_, or via a package manager such as `Anaconda
 <https://www.anaconda.com/>`_, `WinPython <https://winpython.github.io/>`_,
 `MacPorts <https://www.macports.org/>`_, `HomeBrew <https://brew.sh/>`_,
 `APT <https://en.wikipedia.org/wiki/APT_(software)>`_ etc.

--- a/docs/source/inventory.rst
+++ b/docs/source/inventory.rst
@@ -1,0 +1,6 @@
+inventory
+=========
+
+.. automodule:: radioactivedecay.inventory
+   :members:
+   

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -8,7 +8,7 @@ Introduction
 It contains functions to define inventories of radionuclides, perform
 decay calculations, and output decay data for radionuclides and decay chains.
 
-The orignal goal was to create a simple and light weight Python package for
+The original goal was to create a simple and light weight Python package for
 radioactive decay calculations, with full support for branching decays and
 multi-step decay chains, including those which pass through metastable states.
 ``radioactivedecay`` uses the decay data from ICRP Publication 107
@@ -41,9 +41,9 @@ Import the ``radioactivedecay`` package and decay a simple inventory using:
     >>> inv_t1.contents
     {'H-3': 5.0}
 
-Here we created an inventory of 10.0 units of tritum (:sup:`3`\H) and decayed it for
-12.32 years. The activity reduced by a factor of two, i.e. to 5.0 units, as
-12.32 years is the half-life of tritium,
+Here we created an inventory of 10.0 units of tritium (:sup:`3`\H) and decayed
+it for 12.32 years. The activity reduced by a factor of two, i.e. to 5.0 units,
+as 12.32 years is the half-life of tritium.
 
 ``radioactivedecay`` is agnostic to activity units: the output units are the
 same as the input units. The above example could therefore represent 10.0 Bq of
@@ -63,7 +63,7 @@ The `notebooks folder
 in the GitHub repository contains some Jupyter Notebooks for creating the 
 `ICRP 107 decay dataset
 <https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/icrp107_dataset/icrp107_dataset.ipynb>`_
-for radioactivedecay, and cross-checks against `PyNE
+for ``radioactivedecay``, and cross-checks against `PyNE
 <https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/comparisons/pyne/rd_pyne_truncated_compare.ipynb>`_ 
 :ref:`[5] <refs>` and `Radiological Toolbox 
 <https://github.com/alexmalins/radioactivedecay/tree/main/notebooks/comparisons/radiological_toolbox/radiological_toolbox_compare.ipynb>`_
@@ -79,13 +79,13 @@ At present ``radioactivedecay`` has the following limitations:
 * It cannot model external sources of radioactivity input to or removal from an
   inventory over time.
 * ``radioactivedecay`` uses double precision floating point numbers for
-  calculations. Numerical precision issues can arise for decay chains where the
-  half-life of the parent is many orders of magnitude smaller than the half-life
-  of one of the progeny. Similarly there can be precision issues when two
-  radionuclides in a chain have very similar (or identical) half-lives. Note that
-  this latter case does not appear to apply to radionuclides within ICRP 107
-  dataset, however. If you need greater numerical precision for your decay
-  calculations, you could investigate using the `batemaneq 
+  calculations. Numerical precision issues can arise when the half-lives of two
+  radionuclides in the same decay chain differ by many orders of magnitude.
+  Similarly there can be precision issues when two radionuclides in the same
+  chain have very similar (or identical) half-lives. Note however that none of
+  the radionuclides in the decay chains in ICRP 107 fall into the latter
+  category. If you need greater numerical precision for your decay
+  calculations, you could investigate using the `batemaneq
   <https://pypi.org/project/batemaneq/>`_ :ref:`[7] <refs>` package which
   supports `arbitrary precision calculations
   <https://bjodah.github.io/blog/posts/bateman-equation.html>`_.
@@ -96,21 +96,22 @@ At present ``radioactivedecay`` has the following limitations:
 There are also some limitations associated with the ICRP 107 decay dataset:
 
 * ICRP 107 does not contain data on branching fractions for radionuclides
-  produced from spontaneous fission decays. Thus ``decay()`` calls do not
-  calculate the spontaneous fission progeny.
+  produced from spontaneous fission decays. Thus ``decay()`` does not calculate
+  the activities of spontaneous fission progeny.
 * Decay data is quoted in ICRP 107 with up to 5 significant figures of
   precision. The results of decay calculations will therefore not be more precise
   than this level of precision.
 * Uncertainties are not quoted for the radioactive decay data in ICRP 107.
-  Uncertainties will vary substantially between radionuclides, e.g. depending on
-  how well each radionuclide has been researched in the past. In many cases these
-  uncertainties more significant for the results of decay calculations than the
-  previous point about the quoted precision of the ICRP 107 decay data.
+  Uncertainties will vary substantially between radionuclides. They will depend
+  on how well each radionuclide has been researched in the past. In many cases
+  these uncertainties will be more significant for the results of decay
+  calculations than the previous point about the quoted precision of the ICRP
+  107 decay data.
 * There are a few instances where minor decay pathways were not included in
-  ICRP 107. Examples include the decays At-219-> Rn-219 (|beta| ~3%),
-  Es-250 -> Bk-246 (|alpha| ~1.5%), and U-228 -> Pa-228
-  (|epsilon| ~2.5%). For more details see refs. :ref:`[8] <refs>` and
-  :ref:`[9] <refs>` on the creation of the ICRP 107 dataset.
+  ICRP 107, e.g. the decay pathways for At-219-> Rn-219 (|beta| ~3%), Es-250 ->
+  Bk-246 (|alpha| ~1.5%), and U-228 -> Pa-228 (|epsilon| ~2.5%). For more
+  details see refs. :ref:`[8] <refs>` and :ref:`[9] <refs>` on the creation of
+  the ICRP 107 dataset.
 
 License
 -------
@@ -138,8 +139,18 @@ Special thanks to:
 
 * `Center for Computational Science & e-Systems <https://ccse.jaea.go.jp/index_eng.html>`_, `JAEA <https://www.jaea.go.jp/english>`_.
 * `Kenny McKee <https://github.com/Rolleroo>`_
+* `Daniel Jewell <https://github.com/danieldjewell>`_
 
 for their support and assistance to this project.
+
+Thanks also to:
+
+* `Björn Dahlgren <https://github.com/bjodah>`_ (author of the
+  `batemaneq <https://pypi.org/project/batemaneq/>`_ package)
+* `Anthony Scopatz <https://github.com/scopatz>`_ and the PyNE project
+  :ref:`[5] <refs>`
+
+for their work on radioactive decay calculation software.
 
 .. _refs:
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -37,8 +37,6 @@ Import the ``radioactivedecay`` package and decay a simple inventory using:
 
     >>> import radioactivedecay as rd
     >>> inv_t0 = rd.Inventory({'H-3': 10.0})
-    >>> inv_t0.contents
-    {'H-3': 10.0}
     >>> inv_t1 = inv_t0.decay(12.32, 'y')
     >>> inv_t1.contents
     {'H-3': 5.0}

--- a/docs/source/radionuclide.rst
+++ b/docs/source/radionuclide.rst
@@ -1,0 +1,6 @@
+radionuclide
+============
+
+.. automodule:: radioactivedecay.radionuclide
+   :members:
+   

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -4,8 +4,9 @@ Theory
 Solution to the decay chain differential equations
 --------------------------------------------------
 
-``radioactivedecay`` implements an analytical solution to the decay chain
-differential equations outlined by Amaku et al. :ref:`[1] <refs>`.
+``radioactivedecay`` calculates an analytical solution to the decay chain
+differential equations using the method outlined by Amaku et al. :ref:`[1]
+<refs>`.
 
 Consider a system of :math:`n` radionuclides, where the vector
 :math:`\mathbf{N}(t)` has elements :math:`N_{i}(t)` representing the number
@@ -30,7 +31,7 @@ where :math:`\lambda_{j}` is the decay constant of radionuclide :math:`j`,
 and :math:`b_{ji}` is the branching fraction from radionuclide :math:`j` to 
 :math:`i`.
 
-:math:`\varLambda` is a diagonizable matrix so its eigendecomposition can be
+:math:`\varLambda` is a diagonalizable matrix so its eigendecomposition can be
 used to rewrite the matrix differential equation as
 
 .. math::
@@ -70,15 +71,15 @@ condition :math:`\mathbf{N}(t=0)=\mathbf{N}(0)` is
 .. math::
     \mathbf{N}(t) = C e^{\varLambda_{d} t} C^{-1} \mathbf{N}(0).
 
-This is the equation that is calculated by ``radioactivedecay`` in each call to
-``decay()``. :math:`e^{\varLambda_{d} t}` is the matrix exponential of
+This is the equation that is calculated by ``radioactivedecay`` upon each call
+to ``decay()``. :math:`e^{\varLambda_{d} t}` is the matrix exponential of
 :math:`\varLambda_{d} t`. It is a diagonal matrix with elements
 :math:`e^{\varLambda_{d} t}_{ii} = e^{-\lambda_i t}`. 
 
 The final equation that is needed is the conversion between the activity
 (:math:`\mathbf{A}`) and number of atoms (:math:`\mathbf{N}`) vectors.
-:math:`\mathbf{A}` is just an element-wise multiplication of the decay constant
-and number of atom vectors:
+:math:`\mathbf{A}` is just an element-wise multiplication of the decay constants
+and the number of atoms:
 
 .. math::
     A_i = \lambda_i N_i.

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -1,10 +1,10 @@
 Theory
 ======
 
-Solution to decay chain differential equations
-----------------------------------------------
+Solution to the decay chain differential equations
+--------------------------------------------------
 
-``radioactivedecay`` implements the analytical solution to the decay chain
+``radioactivedecay`` implements an analytical solution to the decay chain
 differential equations outlined by Amaku et al. :ref:`[1] <refs>`.
 
 Consider a system of :math:`n` radionuclides, where the vector
@@ -30,24 +30,30 @@ where :math:`\lambda_{j}` is the decay constant of radionuclide :math:`j`,
 and :math:`b_{ji}` is the branching fraction from radionuclide :math:`j` to 
 :math:`i`.
 
-The analytical solution to the differential equation can be expressed as
+:math:`\varLambda` is a diagonizable matrix so its eigendecomposition can be
+used to rewrite the matrix differential equation as
 
 .. math::
-    \mathbf{N}(t) = C E C^{-1} \mathbf{N}(0),
 
-where :math:`E` is a diagonal matrix with elements
-:math:`E_{ii} = e^{-\lambda_i t}`. :math:`C` is a lower triangular matrix with
-elements
+    \frac{\mathrm{d}\mathbf{N}}{\mathrm{d}t} = C \varLambda_d C^{-1} \mathbf{N}.
+
+Here :math:`\varLambda_d` is a diagonal matrix whose elements along the
+diagonal are the negative decay constants
+(:math:`\varLambda_{dii} = -\lambda_{i}`, these are the eigenvalues of
+:math:`\varLambda`). Matrix :math:`C` and its inverse :math:`C^{-1}` are both
+lower triangular matrices. The column vectors of :math:`C` are the eigenvectors
+of :math:`\varLambda`. Amaku et al. showed the elements of :math:`C` can be
+calculated as
 
 .. math::
     C_{ij} =
     \begin{cases}
     0 && \text{for }  i < j,\\
     1 && \text{for }  i = j,\\
-    \frac{\sum_{k=j}^{i-1}\varLambda_{ik}C_{kj}}{\varLambda_{jj} - \varLambda_{ii}} && \text{for }  i > j,
+    \frac{\sum_{k=j}^{i-1}\varLambda_{ik}C_{kj}}{\varLambda_{jj} - \varLambda_{ii}} && \text{for }  i > j.
     \end{cases}
 
-and :math:`C^{-1}` is the inverse of :math:`C` that can be calculated as
+The elements of the inverse matrix :math:`C^{-1}` can then be calculated as
 
 .. math::
     C^{-1}_{ij} =
@@ -56,22 +62,42 @@ and :math:`C^{-1}` is the inverse of :math:`C` that can be calculated as
     1 && \text{for }  i = j,\\
     -\sum_{k=j}^{i-1} C_{ik} C^{-1}_{kj} && \text{for }  i > j.
     \end{cases}
+
+
+The analytical solution to the matrix differential equation given the intial
+condition :math:`\mathbf{N}(t=0)=\mathbf{N}(0)` is
+
+.. math::
+    \mathbf{N}(t) = C e^{\varLambda_{d} t} C^{-1} \mathbf{N}(0).
+
+This is the equation that is calculated by ``radioactivedecay`` in each call to
+``decay()``. :math:`e^{\varLambda_{d} t}` is the matrix exponential of
+:math:`\varLambda_{d} t`. It is a diagonal matrix with elements
+:math:`e^{\varLambda_{d} t}_{ii} = e^{-\lambda_i t}`. 
+
+The final equation that is needed is the conversion between the activity
+(:math:`\mathbf{A}`) and number of atoms (:math:`\mathbf{N}`) vectors.
+:math:`\mathbf{A}` is just an element-wise multiplication of the decay constant
+and number of atom vectors:
+
+.. math::
+    A_i = \lambda_i N_i.
     
 Implementation in radioactivedecay
 ----------------------------------
 
 As matrices :math:`C` and :math:`C^{-1}` are independent of time, they can be
 pre-calculated and imported into ``radioactivedecay`` as part of a radioactive
-decay dataset. They are pre-calculated for the ICRP-107 dataset
-:ref:`[2] <refs>` in this
-`Jupter notebook <https://github.com/alexmalins/radioactivedecay/notebooks/tree/main/icrp107_dataset/icrp107_dataset.ipynb>`_
-held in the package GitHub repository.
+decay dataset.  :math:`C` and :math:`C^{-1}`  are pre-calculated for the
+ICRP-107 :ref:`[2] <refs>` dataset in
+`this Jupter notebook <https://github.com/alexmalins/radioactivedecay/notebooks/tree/main/icrp107_dataset/icrp107_dataset.ipynb>`_
+held in the GitHub repository.
 
-Note that :math:`C`, :math:`C^{-1}` and :math:`E` are sparse matrices. Storing
-the matrices in sparse format greatly reduces the amount of memory that they
-occupy and the computational time for the matrix multiplications. These
-matrices are therefore stored in SciPy Compressed Sparse Column (CSC) matrix
-format in ``radioactivedecay``.
+Note that :math:`C`, :math:`C^{-1}` and :math:`e^{\varLambda_{d} t}` are sparse
+matrices. Storing the matrices in a sparse matrix format greatly reduces the
+amount of memory that they occupy and the computational time for the matrix
+multiplications in the ``decay()`` operation. The matrices are therefore stored
+in SciPy Compressed Sparse Column (CSC) matrix format in ``radioactivedecay``.
 
 References
 ----------

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -19,8 +19,10 @@ Create an inventory of radionuclides and associated activities as follows:
 
     >>> inv_t0 = rd.Inventory({'U-238': 99.274, 'U-235': 0.720, 'U-234': 0.005})
 
-The following commands can be used to view the contents (radionuclides and
-their actitivites) and decay data set associated with an inventory:
+This is an inventory of natural uranium.
+
+The following commands can be used to view the contents (the radionuclides and
+their activities) and decay data set associated with an inventory:
 
 .. code-block:: python3
 
@@ -30,11 +32,14 @@ their actitivites) and decay data set associated with an inventory:
     ['U-234', 'U-235', 'U-238']
     >>> inv_t0.activities
     [0.005, 0.72, 99.274]
+    >>> inv_t0
+    Inventory: {'U-234': 0.005, 'U-235': 0.72, 'U-238': 99.274}, decay dataset: icrp107
 
 Radioactive decay calculations
 ------------------------------
 
-Use ``decay()`` to decay the natural uranium inventory for a billion years:
+Use ``decay()`` to perform a radioactive decay calculation on the natural
+uranium inventory:
 
 .. code-block:: python3
 
@@ -59,15 +64,19 @@ Use ``decay()`` to decay the natural uranium inventory for a billion years:
      'U-234': 85.01287846492669, 'U-235': 0.2689881021544942,
      'U-238': 85.00820732184867}
     
-``decay()`` takes two arguments: the decay time period and its units. The units
-can be entered using :code:`'s'`, :code:`'m'`, :code:`'h'`, :code:`'d'`,
-:code:`'y'` for seconds, minutes, hours, days and years, respectively.
+The ``decay()`` method takes two arguments: the decay time period and its
+units. Units can be entered using :code:`'ns'`, :code:`'us'`, :code:`'ms'`,
+:code:`'s'`, :code:`'m'`, :code:`'h'`, :code:`'d'`, :code:`'y'`, :code:`'ky'`,
+:code:`'My'`, :code:`'Gy'`, :code:`'Ty'` and :code:`'Py'` for nanoseconds,
+microseconds, milliseconds, seconds, minutes, hours, days, years, kiloyears,
+megayears, gigayears, terayears and petayears, respectively. In the above case
+we decayed for one billion years.
 
 Radionuclide name formatting and metastable states
 --------------------------------------------------
 
-Radionuclides can be specified in three different ways. The following are all
-equivalent ways to specify radon-222:
+Radionuclides can be specified in three equivalent ways. These all give
+radon-222:
 
 .. code-block:: python3
 
@@ -75,23 +84,23 @@ equivalent ways to specify radon-222:
     >>> inv = rd.Inventory({'Rn222': 1.0})
     >>> inv = rd.Inventory({'222Rn': 1.0})
 
-First and second metastable states of radionuclides can be inputted using
-\'m\' and \'n\', respectively, i.e.:
+Metastable states of radionuclides can be inputted using \'m\', \'n\', etc. for
+first, second... metastable states, respectively:
 
 .. code-block:: python3
 
     >>> inv1 = rd.Inventory({'Ir-192m': 1.0})
     >>> inv2 = rd.Inventory({'Ir-192n': 1.0})
 
-Equivalently you could have specified these metastable states using
+Equivalently we could have specified these metastable states using
 :code:`'Ir192m'` or :code:`'192mIr'` for the former, or :code:`'Ir192n'` or
 :code:`'192nIr'` for the latter.
 
 Fetching decay data
 -------------------
 
-Use to ``Radionuclide`` class to obtain decay data for individual
-radionuclides. For example, to get the half-life of :sup:`123`\ I:
+The ``Radionuclide`` class can be used to obtain decay data for individual
+radionuclides. For example, to get the half-life of iodine-123:
 
 .. code-block:: python3
 
@@ -100,7 +109,7 @@ radionuclides. For example, to get the half-life of :sup:`123`\ I:
     13.27
 
 The argument for the ``half_life()`` method is your desired time unit for the
-outputted half-life. The default  is seconds if no unit is specified.
+output. The default is seconds if no unit is specified.
 
 Use the ``progeny()``, ``branching_fractions()`` and ``decay_modes()`` methods
 to obtain the progeny, branching fractions and decay modes:
@@ -114,11 +123,37 @@ to obtain the progeny, branching fractions and decay modes:
     >>> nuc.decay_modes()
     ['EC', 'EC']
     
-The methods return data for the direct progeny of the radionuclide. EC stands
-for an electron capture decay mode.
+The methods return data for the direct progeny of the radionuclide. \'EC\' is
+the abbreviation for the electron capture decay mode.
 
-Decay data can be obtained directly from the decay datasets. To query the data
-in ICRP-107, which is the default dataset in ``radioactivedecay``, use:
+The ``decay_modes()`` method reports the types of decay of the parent which
+result in each progeny. The decay modes in the ICRP-107 dataset are \'α\'
+(alpha decay), \'β-\' (beta minus decay), \'β+\' (positron emission), \'EC\'
+(electron capture), \'IT\' (isomeric transition) and \'SF\' (spontaneous
+fission). Note that a decay mode is not a comprehensive list of all the
+radiation types released by the radionuclide decay. Be aware that other
+radiation types, such as gamma rays, electrons and  x-rays, may be released
+from parent to progeny decay mode with only a single label (e.g. \'α\', \'β-\'
+or \'β+\').
+
+Decay data can be accessed for all radionuclides in an ``Inventory``
+by using the ``half_lives()``, ``progeny()``, ``branching_fractions()`` and
+``decay_modes()`` methods:
+
+.. code-block:: python3
+
+    >>> inv = rd.Inventory({'C-14': 1.0, 'K-40': 2.0})
+    >>> inv.half_lives('y')
+    {'C-14': 5700.0, 'K-40': 1251000000.0}
+    >>> inv.progeny()
+    {'C-14': ['N-14'], 'K-40': ['Ca-40', 'Ar-40']}
+    >>> inv.branching_fractions()
+    {'C-14': [1.0], 'K-40': [0.8914, 0.1086]}
+    >>> inv.decay_modes()
+    {'C-14': ['β-'], 'K-40': ['β-', 'β+ & EC']}
+
+Decay data can also be accessed directly from the decay datasets. To query the
+data in ICRP-107, which is the default dataset in ``radioactivedecay``, use:
 
 .. code-block:: python3
 
@@ -131,10 +166,11 @@ in ICRP-107, which is the default dataset in ``radioactivedecay``, use:
     >>> rd.DEFAULTDATA.decay_mode('Cs-137', 'Ba-137m')
     'β-'
 
+
 Adding and removing radionuclides from inventories
 --------------------------------------------------
 
-It is easy to add radionuclides to inventories using the ``add()`` method:
+It is easy to add radionuclides to an ``Inventory`` using the ``add()`` method:
 
 .. code-block:: python3
 
@@ -145,7 +181,8 @@ It is easy to add radionuclides to inventories using the ``add()`` method:
     >>> inv.contents
     {'Be-10': 2.0, 'C-14': 3.0, 'H-3': 1.0, 'K-40': 4.0}
 
-Likewise use ``remove()`` to erase one or more radionuclides from an inventory:
+Likewise use ``remove()`` to erase one or more radionuclide from an
+``Inventory``:
 
 .. code-block:: python3
 
@@ -156,10 +193,31 @@ Likewise use ``remove()`` to erase one or more radionuclides from an inventory:
     >>> inv.contents
     {'C-14': 3.0}
 
+You can also supply ``Radionuclide`` objects instead of strings to the
+``Inventory`` constructor, and the ``add()`` and ``remove()`` methods:
+
+.. code-block:: python3
+
+    >>> H3 = rd.Radionuclide('H-3')
+    >>> inv = rd.Inventory({H3: 1.0})
+    >>> inv.contents
+    {'H-3': 1.0}
+    >>> Be10 = rd.Radionuclide('Be-10')
+    >>> inv.add({Be10: 2.0})
+    >>> inv.contents
+    {'Be-10': 2.0, 'H-3': 1.0}
+    >>> inv.remove(H3)
+    >>> inv.contents
+    {'Be-10': 2.0}
+
+Note if the decay dataset of the ``Radionuclide`` instance is different to that
+of the ``Inventory`` instance, the former will be ignored and the existing
+decay dataset of the ``Inventory`` will be used instead.
+
 Inventory arithmetic
 --------------------
 
-You can add the conents of different inventories together to create a new
+You can add the contents of different inventories together to create a new
 inventory:
 
 .. code-block:: python3
@@ -181,7 +239,7 @@ It is also possible to subtract the contents of one inventory from another:
 Multiplication and division on inventories
 ------------------------------------------
 
-You can multipy or divide the activites of all radionuclides in an inventory
+You can multiply or divide the activities of all radionuclides in an inventory
 by a constant as follows:
 
 .. code-block:: python3

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -129,7 +129,7 @@ in ICRP-107, which is the default dataset in ``radioactivedecay``, use:
     >>> rd.DEFAULTDATA.branching_fraction('Cs-137', 'Ba-137m')
     0.94399
     >>> rd.DEFAULTDATA.decay_mode('Cs-137', 'Ba-137m')
-    'É¿-'
+    'Œ≤-'
 
 Adding and removing radionuclides from inventories
 --------------------------------------------------

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -84,10 +84,11 @@ First and second metastable states of radionuclides can be inputted using
     >>> inv2 = rd.Inventory({'Ir-192n': 1.0})
 
 Equivalently you could have specified these metastable states using
-:code:`'Ir192m'`, :code:`'192mIr'`, :code:`'Ir192n'` or :code:`'192nIr'`.
+:code:`'Ir192m'` or :code:`'192mIr'` for the former, or :code:`'Ir192n'` or
+:code:`'192nIr'` for the latter.
 
-Decay data for individual radionuclides
----------------------------------------
+Fetching decay data
+-------------------
 
 Use to ``Radionuclide`` class to obtain decay data for individual
 radionuclides. For example, to get the half-life of :sup:`123`\ I:
@@ -114,7 +115,21 @@ to obtain the progeny, branching fractions and decay modes:
     ['EC', 'EC']
     
 The methods return data for the direct progeny of the radionuclide. EC stands
-for an electron capture decay mode. 
+for an electron capture decay mode.
+
+Decay data can be obtained directly from the decay datasets. To query the data
+in ICRP-107, which is the default dataset in ``radioactivedecay``, use:
+
+.. code-block:: python3
+
+    >>> rd.DEFAULTDATA.dataset
+    'icrp107'
+    >>> rd.DEFAULTDATA.half_life('Cs-137', 'y')
+    30.1671
+    >>> rd.DEFAULTDATA.branching_fraction('Cs-137', 'Ba-137m')
+    0.94399
+    >>> rd.DEFAULTDATA.decay_mode('Cs-137', 'Ba-137m')
+    'É¿-'
 
 Adding and removing radionuclides from inventories
 --------------------------------------------------

--- a/notebooks/icrp107_dataset/icrp107_dataset.ipynb
+++ b/notebooks/icrp107_dataset/icrp107_dataset.ipynb
@@ -509,7 +509,7 @@
     "- β- decay: $\\mathrm{^{A}_{Z}X} \\rightarrow \\mathrm{^{A}_{Z+1}Y}$\n",
     "- α decay: $\\mathrm{^{A}_{Z}X} \\rightarrow \\mathrm{^{A-4}_{Z-2}Y}$\n",
     "- IT decay: $\\mathrm{^{Am}_{Z}X} \\rightarrow \\mathrm{^{A}_{Z}X}$ or $\\mathrm{^{An}_{Z}X} \\rightarrow \\mathrm{^{A}_{Z}X}$\n",
-    "- SF decay: radioactivedecay does not evaluate radioactive progeny from spontaneous fission\n",
+    "- SF decay: The ICRP-107 dataset does not contain data for the outcomes (progeny) from spontaneous fission decays\n",
     "\n",
     "We order by decreasing mass number (A), followed by decreasing atomic number (Z) (as there are more Beta+ and EC decays than Beta- decays), then by decreasing isomer index (n, m, ground state)."
    ]

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -7,4 +7,6 @@ equations analytically using NumPy and SciPy linear algebra routines.
 
 __version__ = "0.0.9"
 
-from radioactivedecay.decayfunctions import *
+from radioactivedecay.decaydata import DecayData, DEFAULTDATA
+from radioactivedecay.radionuclide import Radionuclide
+from radioactivedecay.inventory import Inventory

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -5,6 +5,6 @@ decay data from ICRP Publication 107. It solves the decay chain differential
 equations analytically using NumPy and SciPy linear algebra routines.
 """
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 from radioactivedecay.decayfunctions import *

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -10,6 +10,10 @@ The examples shown assume the ``radioactivedecay`` package has been imported as:
 
     >>> import radioactivedecay as rd
 
+Attributes
+----------
+DEFAULTDATA : DecayData
+    Default decay dataset used by ``radioactivedecay``. This is currently ICRP 107.
 """
 
 from pathlib import Path

--- a/radioactivedecay/decayfunctions.py
+++ b/radioactivedecay/decayfunctions.py
@@ -98,6 +98,13 @@ class Inventory:
 
         return list(self.contents.values())
 
+    def __len__(self):
+        """
+        Returns number of radionuclides in this inventory.
+        """
+
+        return len(self.contents)
+
     def add(self, add_contents):
         """
         Adds a dictionary of radionuclides and associated activities to this inventory.

--- a/radioactivedecay/decayfunctions.py
+++ b/radioactivedecay/decayfunctions.py
@@ -9,10 +9,6 @@ The examples shown assume the ``radioactivedecay`` package has been imported as:
 
     >>> import radioactivedecay as rd
 
-Attributes
-----------
-DEFAULTDATA : DecayData
-    Default decay dataset used by ``radioactivedecay``. This is currently ICRP 107.
 """
 
 from typing import Callable, Dict, List, Union

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -1,5 +1,8 @@
 """
-The inventory module defines the ``Inventory`` class.
+The inventory module defines the ``Inventory`` class. Each ``Inventory`` instance contains one or
+more radionuclides, each with an assoicated activity. The decay of the radionuclide(s) in an
+``Inventory`` can be calculated by using the ``decay()`` method. A ``DecayData`` dataset is
+associated with each ``Inventory`` instance (default is DEFAULTDATA).
 
 The examples shown assume the ``radioactivedecay`` package has been imported as:
 
@@ -15,26 +18,83 @@ from radioactivedecay.decaydata import DecayData, DEFAULTDATA, np
 from radioactivedecay.radionuclide import Radionuclide
 from radioactivedecay.utils import (
     parse_radionuclide,
-    check_dictionary,
     time_unit_conv,
     add_dictionaries,
     method_dispatch,
 )
 
 
+def check_dictionary(
+    input_inv_dict: Dict[Union[str, Radionuclide], float],
+    radionuclides: List[str],
+    dataset: str,
+) -> Dict[str, float]:
+    """
+    Checks validity of a dictionary of radionuclides and associated acitivities. Radionuclides
+    must be in the decay dataset. Radionuclide strings are parsed to to Ab-XX format.
+
+    Parameters
+    ----------
+    input_inv_dict : dict
+        Dictionary containing radionuclide strings or Radionuclide objects as keys and activities
+        as values.
+    radionuclides : List[str]
+        List of all the radionuclides in the decay dataset.
+    dataset : str
+        Name of the decay dataset.
+
+    Returns
+    -------
+    dict
+        Dictionary where the contents have been validated and the keys (radionuclide strings) have
+        been parsed into symbol - mass number format.
+
+    Raises
+    ------
+    ValueError
+        If an activity key is invalid.
+
+    Examples
+    --------
+    >>> rd.inventory.check_dictionary({'3H': 1.0}, rd.DEFAULTDATA.radionuclides, rd.DEFAULTDATA.dataset)
+    {'H-3': 1.0}
+    >>> H3 = rd.Radionuclide('H-3')
+    >>> rd.inventory.check_dictionary({H3: 1.0}, rd.DEFAULTDATA.radionuclides, rd.DEFAULTDATA.dataset)
+    {'H-3': 1.0}
+
+    """
+
+    inv_dict: Dict[str, float] = {
+        (
+            parse_radionuclide(nuc.radionuclide, radionuclides, dataset)
+            if isinstance(nuc, Radionuclide)
+            else parse_radionuclide(nuc, radionuclides, dataset)
+        ): act
+        for nuc, act in input_inv_dict.items()
+    }
+    for nuc, act in inv_dict.items():
+        if not isinstance(act, (float, int)):
+            raise ValueError(
+                str(act) + " is not a valid radioactivity for " + str(nuc) + "."
+            )
+
+    return inv_dict
+
+
 class Inventory:
     """
-    Inventory instances store a dictionary of radionuclides and associated activities, and a
-    DecayData object of radioactive decay data.
+    ``Inventory`` instances store a dictionary of radionuclides and associated activities, and a
+    ``DecayData`` instance of radioactive decay data.
 
     Parameters
     ----------
     contents : dict
-        Dictionary containing radionuclide strings as keys and activities as values.
+        Dictionary containing radionuclide strings or Radionuclide objects as keys and activities
+        as values.
     check : bool, optional
         Check for the validity of contents (default is True).
     data : DecayData, optional
-        Decay dataset (default is the ICRP 107 dataset).
+        Decay dataset (default is the ICRP-107 dataset).
 
     Attributes
     ----------
@@ -47,29 +107,41 @@ class Inventory:
     Examples
     --------
     >>> rd.Inventory({'Tc-99m': 2.3, 'I-123': 5.8})
-    Inventory: {'I-123': 5.8, 'Tc-99m': 2.3}, Decay dataset: icrp107
+    Inventory: {'I-123': 5.8, 'Tc-99m': 2.3}, decay dataset: icrp107
+    >>> H3 = rd.Radionuclide('H-3')
+    >>> rd.Inventory({H3: 3.0})
+    Inventory: {'H-3': 3.0}, decay dataset: icrp107
 
     """
 
     def __init__(
         self,
-        contents: Dict[str, float],
+        contents: Dict[Union[str, Radionuclide], float],
         check: bool = True,
         data: DecayData = DEFAULTDATA,
     ) -> None:
-        if check is True:
-            contents = check_dictionary(contents, data.radionuclides, data.dataset)
-        self.contents = dict(sorted(contents.items(), key=lambda x: x[0]))
-        self.data = data
+        parsed_contents: Dict[str, float] = check_dictionary(
+            contents, data.radionuclides, data.dataset
+        ) if check is True else contents
+        self.contents: Dict[str, float] = dict(
+            sorted(parsed_contents.items(), key=lambda x: x[0])
+        )
+        self.data: DecayData = data
 
-    def change(self, contents: Dict[str, float], check: bool, data) -> None:
+    def change(
+        self,
+        contents: Dict[Union[str, Radionuclide], float],
+        check: bool,
+        data: DecayData,
+    ) -> None:
         """
         Changes the contents and data attritubes of this Inventory instance.
         """
 
-        if check is True:
-            contents = check_dictionary(contents, data.radionuclides, data.dataset)
-        self.contents = dict(sorted(contents.items(), key=lambda x: x[0]))
+        parsed_contents: Dict[str, float] = check_dictionary(
+            contents, data.radionuclides, data.dataset
+        ) if check is True else contents
+        self.contents = dict(sorted(parsed_contents.items(), key=lambda x: x[0]))
         self.data = data
 
     @property
@@ -89,7 +161,7 @@ class Inventory:
     @property
     def activities(self) -> List[float]:
         """
-        Returns a list of the radionuclides in the Inventory.
+        Returns a list of the activities of the radionuclides in the Inventory.
 
         Examples
         --------
@@ -107,15 +179,15 @@ class Inventory:
 
         return len(self.contents)
 
-    def add(self, add_contents: Dict[str, float]) -> None:
+    def add(self, add_contents: Dict[Union[str, Radionuclide], float]) -> None:
         """
         Adds a dictionary of radionuclides and associated activities to this inventory.
 
         Parameters
         ----------
         add_contents : dict
-            Dictionary containing radionuclide strings as keys and activities as values which are
-            added to the Inventory object.
+            Dictionary containing radionuclide strings or Radionuclide objects as keys and
+            activities as values which are added to the Inventory object.
 
         Examples
         --------
@@ -126,21 +198,21 @@ class Inventory:
 
         """
 
-        add_contents = check_dictionary(
+        parsed_add_contents: Dict[str, float] = check_dictionary(
             add_contents, self.data.radionuclides, self.data.dataset
         )
-        new_contents = add_dictionaries(self.contents, add_contents)
+        new_contents = add_dictionaries(self.contents, parsed_add_contents)
         self.change(new_contents, False, self.data)
 
-    def subtract(self, sub_contents: Dict[str, float]) -> None:
+    def subtract(self, sub_contents: Dict[Union[str, Radionuclide], float]) -> None:
         """
         Subtracts a dictionary of radionuclides and associated activities from this inventory.
 
         Parameters
         ----------
         sub_contents : dict
-            Dictionary containing radionuclide strings as keys and activities as values which are
-            subtracted from the Inventory object.
+            Dictionary containing radionuclide strings or Radionuclide objects as keys and
+            activities as values which are subtracted from the Inventory object.
 
         Examples
         --------
@@ -150,14 +222,14 @@ class Inventory:
         {'C-14': 2.0, 'H-3': 0.0}
 
         """
-        sub_contents = check_dictionary(
+        parsed_sub_contents: Dict[str, float] = check_dictionary(
             sub_contents, self.data.radionuclides, self.data.dataset
         )
-        sub_contents.update(
+        parsed_sub_contents.update(
             (nuclide, radioactivity * -1.0)
-            for nuclide, radioactivity in sub_contents.items()
+            for nuclide, radioactivity in parsed_sub_contents.items()
         )
-        new_contents = add_dictionaries(self.contents, sub_contents)
+        new_contents = add_dictionaries(self.contents, parsed_sub_contents)
         self.change(new_contents, False, self.data)
 
     def __add__(self, other: "Inventory") -> "Inventory":
@@ -223,15 +295,17 @@ class Inventory:
         return self.__mul__(1.0 / const)
 
     @method_dispatch
-    def remove(self, delete: Union[str, List[str]]) -> None:
+    def remove(
+        self, delete: Union[str, Radionuclide, List[Union[str, Radionuclide]]]
+    ) -> None:
         """
         Removes radionuclide(s) from this inventory.
 
         Parameters
         ----------
-        delete : str or list
-            Radionuclide string or list of radionuclide strings to delete from the Inventory
-            object.
+        delete : str or Radionuclide or list
+            Radionuclide string, Radionuclide object or list of radionuclide strings or
+            Radionuclide Objects to delete from the Inventory object.
 
         Examples
         --------
@@ -255,11 +329,31 @@ class Inventory:
         new_contents.pop(delete)
         self.change(new_contents, False, self.data)
 
+    @remove.register(Radionuclide)
+    def _(
+        self, delete: Radionuclide
+    ) -> Callable[[Dict[str, float], bool, DecayData], None]:
+        """Remove radionuclide string from this inventory."""
+        delete = parse_radionuclide(
+            delete.radionuclide, self.data.radionuclides, self.data.dataset
+        )
+        new_contents = self.contents.copy()
+        if delete not in new_contents:
+            raise ValueError(delete + " does not exist in this inventory.")
+        new_contents.pop(delete)
+        self.change(new_contents, False, self.data)
+
     @remove.register(list)
-    def _(self, delete: str) -> Callable[[Dict[str, float], bool, DecayData], None]:
+    def _(
+        self, delete: List[Union[str, Radionuclide]]
+    ) -> Callable[[Dict[str, float], bool, DecayData], None]:
         """Remove list of radionuclide(s) from this inventory."""
         delete = [
-            parse_radionuclide(nuc, self.data.radionuclides, self.data.dataset)
+            parse_radionuclide(
+                nuc.radionuclide, self.data.radionuclides, self.data.dataset
+            )
+            if isinstance(nuc, Radionuclide)
+            else parse_radionuclide(nuc, self.data.radionuclides, self.data.dataset)
             for nuc in delete
         ]
         new_contents = self.contents.copy()
@@ -329,7 +423,116 @@ class Inventory:
         new_contents = dict(sorted(new_contents.items(), key=lambda x: x[0]))
         return Inventory(new_contents, False, self.data)
 
+    def half_lives(self, units: str = "s") -> Dict[str, float]:
+        """
+        Returns dictionary of half-lives of the radionuclides in the Inventory in chosen time
+        units.
+
+        Parameters
+        ----------
+        units : str, optional
+            Units for half-life (default is seconds). Options are 'ns', 'us', 'ms', 's', 'm', 'h',
+            'd', 'y', 'ky', 'My', 'Gy', 'Ty', 'Py', and some of the common spelling variations of
+            these time units.
+
+        Returns
+        -------
+        dict
+            Dictionary with radionuclide strings as keys and half-life floats as values.
+
+        Examples
+        --------
+        >>> inv = rd.Inventory({'C-14': 1.0, 'K-40': 2.0})
+        >>> inv.half_lives('y')
+        {'C-14': 5700.0, 'K-40': 1251000000.0}
+
+        """
+
+        return {nuc: self.data.half_life(nuc, units) for nuc in self.contents}
+
+    def progeny(self) -> Dict[str, List[str]]:
+        """
+        Returns dictionary with the direct progeny of the radionuclides in the Inventory.
+
+        Returns
+        -------
+        dict
+            Dictionary with radionuclide strings as keys and lists of the direct progeny of each
+            radionuclide, ordered by decreasing branching fraction, as values.
+
+        Examples
+        --------
+        >>> inv = rd.Inventory({'C-14': 1.0, 'K-40': 2.0})
+        >>> inv.progeny()
+        {'C-14': ['N-14'], 'K-40': ['Ca-40', 'Ar-40'])
+
+        """
+
+        return {nuc: Radionuclide(nuc, self.data).progeny() for nuc in self.contents}
+
+    def branching_fractions(self) -> Dict[str, List[float]]:
+        """
+        Returns dictionary with the branching fractions of the direct progeny of the radionuclides
+        in the Inventory.
+
+        Returns
+        -------
+        dict
+            Dictionary with radionuclide strings as keys and lists of the branching fractions to
+            the direct progeny of each radionuclide as values.
+
+        Examples
+        --------
+        >>> inv = rd.Inventory({'C-14': 1.0, 'K-40': 2.0})
+        >>> inv.branching_fractions()
+        {'C-14': [1.0], 'K-40': [0.8914, 0.1086])
+
+        """
+
+        return {
+            nuc: Radionuclide(nuc, self.data).branching_fractions()
+            for nuc in self.contents
+        }
+
+    def decay_modes(self) -> Dict[str, List[str]]:
+        """
+        Returns dictionary with the decay modes of the direct progeny of the radionuclides in the
+        Inventory. Note: the decay modes are not lists of all the different radiation types emitted
+        by the decay.
+
+        Returns
+        -------
+        dict
+            Dictionary with radionuclide strings as keys and lists of the decay modes of the parent
+            radionuclide
+
+        Examples
+        --------
+        >>> inv = rd.Inventory({'C-14': 1.0, 'K-40': 2.0})
+        >>> inv.decay_modes()
+        {'C-14': ['\u03b2-'], 'K-40': ['\u03b2-', '\u03b2+ \u0026 EC'])
+
+        """
+
+        return {
+            nuc: Radionuclide(nuc, self.data).decay_modes() for nuc in self.contents
+        }
+
     def __repr__(self) -> str:
         return (
-            "Inventory: " + str(self.contents) + ", Decay dataset: " + self.data.dataset
+            "Inventory: " + str(self.contents) + ", decay dataset: " + self.data.dataset
         )
+
+    def __eq__(self, other) -> bool:
+        """
+        Check whether two ``Inventory`` instances are equal with ``==`` operator.
+        """
+
+        return self.contents == other.contents and self.data == other.data
+
+    def __ne__(self, other) -> bool:
+        """
+        Check whether two ``Inventory`` instances are not equal with ``!=`` operator.
+        """
+
+        return not self.__eq__(other)

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -1,6 +1,5 @@
 """
-The decacyfunctions module defines the two main classes used by users: the ``Inventory`` and
-``Radionuclide`` classes.
+The inventory module defines the ``Inventory`` class.
 
 The examples shown assume the ``radioactivedecay`` package has been imported as:
 
@@ -12,8 +11,8 @@ The examples shown assume the ``radioactivedecay`` package has been imported as:
 """
 
 from typing import Callable, Dict, List, Union
-import numpy as np
-from radioactivedecay.decaydata import DecayData, DEFAULTDATA
+from radioactivedecay.decaydata import DecayData, DEFAULTDATA, np
+from radioactivedecay.radionuclide import Radionuclide
 from radioactivedecay.utils import (
     parse_radionuclide,
     check_dictionary,
@@ -333,148 +332,4 @@ class Inventory:
     def __repr__(self) -> str:
         return (
             "Inventory: " + str(self.contents) + ", Decay dataset: " + self.data.dataset
-        )
-
-
-class Radionuclide:
-    """
-    Radionuclide instances are used to fetch decay data on one radionuclide.
-
-    Parameters
-    ----------
-    radionuclide : str
-        Radionuclide string.
-    data : DecayData, optional
-        Decay dataset (default is the ICRP 107 dataset).
-
-    Attributes
-    ----------
-    radionuclide : str
-        Radionuclide string.
-    decay_constant : numpy.float64
-        Decay constant of the radionuclide (s\\ :sup:`-1`).
-    prog_bf_mode : dict
-        Dictionary containing direct progeny as keys, and a list containing the branching fraction
-        and the decay mode for that progeny as values.
-    data : DecayData
-        Decay dataset.
-
-    Examples
-    --------
-    >>> rd.Radionuclide('H-3')
-    Radionuclide: H-3, Decay dataset: icrp107
-
-    """
-
-    def __init__(self, radionuclide: str, data: DecayData = DEFAULTDATA) -> None:
-        self.radionuclide = parse_radionuclide(
-            radionuclide, data.radionuclides, data.dataset
-        )
-        self.decay_constant = data.decay_consts[
-            data.radionuclide_dict[self.radionuclide]
-        ]
-        self.prog_bf_mode = data.prog_bfs_modes[
-            data.radionuclide_dict[self.radionuclide]
-        ]
-        self.data = data
-
-    def half_life(self, units: str = "s") -> float:
-        """
-        Returns half-life of the radionuclide in chosen units.
-
-        Parameters
-        ----------
-        units : str, optional
-            Units for half-life (default is seconds). Options are 'ns', 'us', 'ms', 's', 'm', 'h',
-            'd', 'y', 'ky', 'My', 'Gy', 'Ty', 'Py', and some of the common spelling variations of
-            these time units.
-
-        Returns
-        -------
-        float
-            Radionuclide half-life.
-
-        Examples
-        --------
-        >>> Rn222 = rd.Radionuclide('Rn-222')
-        >>> Rn222.half_life('d')
-        3.8235
-
-        """
-
-        conv = (
-            1.0
-            if units == "s"
-            else time_unit_conv(
-                1.0, units_from="s", units_to=units, year_conv=self.data.year_conv
-            )
-        )
-        return conv * self.data.ln2 / self.decay_constant
-
-    def progeny(self) -> List[str]:
-        """
-        Returns the direct progeny of the radionuclide.
-
-        Returns
-        -------
-        list
-            List of the direct progeny of the radionuclide, ordered by decreasing branching
-            fraction.
-
-        Examples
-        --------
-        >>> K40 = rd.Radionuclide('K-40')
-        >>> K40.progeny()
-        ['Ca-40', 'Ar-40']
-
-        """
-
-        return list(self.prog_bf_mode.keys())
-
-    def branching_fractions(self) -> List[float]:
-        """
-        Returns the branching fractions for the direct progeny of the radionuclide.
-
-        Returns
-        -------
-        list
-            List of branching fractions.
-
-        Examples
-        --------
-        >>> K40 = rd.Radionuclide('K-40')
-        >>> K40.branching_fractions()
-        [0.8914, 0.1086]
-
-        """
-
-        return [bf_mode[0] for bf_mode in list(self.prog_bf_mode.values())]
-
-    def decay_modes(self) -> List[str]:
-        """
-        Returns the decay modes for the radionuclide, as defined in the decay dataset. Note: the
-        decay mode does not necessarily list all the different radiation particles emitted by the
-        decay.
-
-        Returns
-        -------
-        list
-            List of decay modes.
-
-        Examples
-        --------
-        >>> K40 = rd.Radionuclide('K-40')
-        >>> K40.decay_modes()
-        ['\u03b2-', '\u03b2+ & EC']
-
-        """
-
-        return [bf_mode[1] for bf_mode in list(self.prog_bf_mode.values())]
-
-    def __repr__(self) -> str:
-        return (
-            "Radionuclide: "
-            + str(self.radionuclide)
-            + ", Decay dataset: "
-            + self.data.dataset
         )

--- a/radioactivedecay/radionuclide.py
+++ b/radioactivedecay/radionuclide.py
@@ -1,5 +1,8 @@
 """
-The radionuclide module defines the ``Radionuclide`` class.
+The radionuclide module defines the ``Radionuclide`` class. Each ``Radionuclide`` instance contains
+decay data for one radionuclide. The data can be accessed via the instance attributes and methods.
+The data comes from the ``DecayData`` dataset which is supplied to the ``Radionuclide`` class
+constructor (default is radioactivedecay.decaydata.DEFAULTDATA).
 
 The examples shown assume the ``radioactivedecay`` package has been imported as:
 
@@ -10,21 +13,22 @@ The examples shown assume the ``radioactivedecay`` package has been imported as:
 
 """
 
-from typing import List
+from typing import Dict, List
 from radioactivedecay.decaydata import DecayData, DEFAULTDATA
 from radioactivedecay.utils import parse_radionuclide, time_unit_conv
 
 
 class Radionuclide:
     """
-    Radionuclide instances are used to fetch decay data on one radionuclide.
+    ``Radionuclide`` instances are used to fetch decay data on one radionuclide. The data comes
+    from the assoicated ``DecayData`` dataset.
 
     Parameters
     ----------
     radionuclide : str
         Radionuclide string.
     data : DecayData, optional
-        Decay dataset (default is the ICRP 107 dataset).
+        Decay dataset (default is the ICRP-107 dataset).
 
     Attributes
     ----------
@@ -40,22 +44,22 @@ class Radionuclide:
 
     Examples
     --------
-    >>> rd.Radionuclide('H-3')
-    Radionuclide: H-3, Decay dataset: icrp107
+    >>> rd.Radionuclide('K-40')
+    Radionuclide: K-40, decay dataset: icrp107
 
     """
 
     def __init__(self, radionuclide: str, data: DecayData = DEFAULTDATA) -> None:
-        self.radionuclide = parse_radionuclide(
+        self.radionuclide: str = parse_radionuclide(
             radionuclide, data.radionuclides, data.dataset
         )
-        self.decay_constant = data.decay_consts[
+        self.decay_constant: float = data.decay_consts[
             data.radionuclide_dict[self.radionuclide]
         ]
-        self.prog_bf_mode = data.prog_bfs_modes[
+        self.prog_bf_mode: Dict[str, List] = data.prog_bfs_modes[
             data.radionuclide_dict[self.radionuclide]
         ]
-        self.data = data
+        self.data: DecayData = data
 
     def half_life(self, units: str = "s") -> float:
         """
@@ -75,9 +79,9 @@ class Radionuclide:
 
         Examples
         --------
-        >>> Rn222 = rd.Radionuclide('Rn-222')
-        >>> Rn222.half_life('d')
-        3.8235
+        >>> K40 = rd.Radionuclide('K-40')
+        >>> K40.half_life('y')
+        1251000000.0
 
         """
 
@@ -112,7 +116,7 @@ class Radionuclide:
 
     def branching_fractions(self) -> List[float]:
         """
-        Returns the branching fractions for the direct progeny of the radionuclide.
+        Returns the branching fractions to the direct progeny of the radionuclide.
 
         Returns
         -------
@@ -132,8 +136,7 @@ class Radionuclide:
     def decay_modes(self) -> List[str]:
         """
         Returns the decay modes for the radionuclide, as defined in the decay dataset. Note: the
-        decay mode does not necessarily list all the different radiation particles emitted by the
-        decay.
+        decay mode is not a list of all the different radiation types emitted by the decay.
 
         Returns
         -------
@@ -154,6 +157,27 @@ class Radionuclide:
         return (
             "Radionuclide: "
             + str(self.radionuclide)
-            + ", Decay dataset: "
+            + ", decay dataset: "
             + self.data.dataset
         )
+
+    def __eq__(self, other) -> bool:
+        """
+        Check whether two ``Radionuclide`` instances are equal with ``==`` operator.
+        """
+
+        return self.radionuclide == other.radionuclide and self.data == other.data
+
+    def __ne__(self, other) -> bool:
+        """
+        Check whether two ``Radionuclide`` instances are not equal with ``!=`` operator.
+        """
+
+        return not self.__eq__(other)
+
+    def __hash__(self) -> int:
+        """
+        Hash function for ``Radionuclide`` instances.
+        """
+
+        return hash((self.radionuclide, self.data.dataset))

--- a/radioactivedecay/radionuclide.py
+++ b/radioactivedecay/radionuclide.py
@@ -1,0 +1,159 @@
+"""
+The radionuclide module defines the ``Radionuclide`` class.
+
+The examples shown assume the ``radioactivedecay`` package has been imported as:
+
+.. highlight:: python
+.. code-block:: python
+
+    >>> import radioactivedecay as rd
+
+"""
+
+from typing import List
+from radioactivedecay.decaydata import DecayData, DEFAULTDATA
+from radioactivedecay.utils import parse_radionuclide, time_unit_conv
+
+
+class Radionuclide:
+    """
+    Radionuclide instances are used to fetch decay data on one radionuclide.
+
+    Parameters
+    ----------
+    radionuclide : str
+        Radionuclide string.
+    data : DecayData, optional
+        Decay dataset (default is the ICRP 107 dataset).
+
+    Attributes
+    ----------
+    radionuclide : str
+        Radionuclide string.
+    decay_constant : numpy.float64
+        Decay constant of the radionuclide (s\\ :sup:`-1`).
+    prog_bf_mode : dict
+        Dictionary containing direct progeny as keys, and a list containing the branching fraction
+        and the decay mode for that progeny as values.
+    data : DecayData
+        Decay dataset.
+
+    Examples
+    --------
+    >>> rd.Radionuclide('H-3')
+    Radionuclide: H-3, Decay dataset: icrp107
+
+    """
+
+    def __init__(self, radionuclide: str, data: DecayData = DEFAULTDATA) -> None:
+        self.radionuclide = parse_radionuclide(
+            radionuclide, data.radionuclides, data.dataset
+        )
+        self.decay_constant = data.decay_consts[
+            data.radionuclide_dict[self.radionuclide]
+        ]
+        self.prog_bf_mode = data.prog_bfs_modes[
+            data.radionuclide_dict[self.radionuclide]
+        ]
+        self.data = data
+
+    def half_life(self, units: str = "s") -> float:
+        """
+        Returns half-life of the radionuclide in chosen units.
+
+        Parameters
+        ----------
+        units : str, optional
+            Units for half-life (default is seconds). Options are 'ns', 'us', 'ms', 's', 'm', 'h',
+            'd', 'y', 'ky', 'My', 'Gy', 'Ty', 'Py', and some of the common spelling variations of
+            these time units.
+
+        Returns
+        -------
+        float
+            Radionuclide half-life.
+
+        Examples
+        --------
+        >>> Rn222 = rd.Radionuclide('Rn-222')
+        >>> Rn222.half_life('d')
+        3.8235
+
+        """
+
+        conv = (
+            1.0
+            if units == "s"
+            else time_unit_conv(
+                1.0, units_from="s", units_to=units, year_conv=self.data.year_conv
+            )
+        )
+        return conv * self.data.ln2 / self.decay_constant
+
+    def progeny(self) -> List[str]:
+        """
+        Returns the direct progeny of the radionuclide.
+
+        Returns
+        -------
+        list
+            List of the direct progeny of the radionuclide, ordered by decreasing branching
+            fraction.
+
+        Examples
+        --------
+        >>> K40 = rd.Radionuclide('K-40')
+        >>> K40.progeny()
+        ['Ca-40', 'Ar-40']
+
+        """
+
+        return list(self.prog_bf_mode.keys())
+
+    def branching_fractions(self) -> List[float]:
+        """
+        Returns the branching fractions for the direct progeny of the radionuclide.
+
+        Returns
+        -------
+        list
+            List of branching fractions.
+
+        Examples
+        --------
+        >>> K40 = rd.Radionuclide('K-40')
+        >>> K40.branching_fractions()
+        [0.8914, 0.1086]
+
+        """
+
+        return [bf_mode[0] for bf_mode in list(self.prog_bf_mode.values())]
+
+    def decay_modes(self) -> List[str]:
+        """
+        Returns the decay modes for the radionuclide, as defined in the decay dataset. Note: the
+        decay mode does not necessarily list all the different radiation particles emitted by the
+        decay.
+
+        Returns
+        -------
+        list
+            List of decay modes.
+
+        Examples
+        --------
+        >>> K40 = rd.Radionuclide('K-40')
+        >>> K40.decay_modes()
+        ['\u03b2-', '\u03b2+ & EC']
+
+        """
+
+        return [bf_mode[1] for bf_mode in list(self.prog_bf_mode.values())]
+
+    def __repr__(self) -> str:
+        return (
+            "Radionuclide: "
+            + str(self.radionuclide)
+            + ", Decay dataset: "
+            + self.data.dataset
+        )

--- a/radioactivedecay/utils.py
+++ b/radioactivedecay/utils.py
@@ -114,54 +114,6 @@ def parse_radionuclide(
     return radionuclide
 
 
-def check_dictionary(
-    inv_dict: Dict[str, float], radionuclides: List[str], dataset: str
-) -> Dict[str, float]:
-    """
-    Checks validity of a dictionary of radionuclides and associated acitivities. Radionuclides
-    must be in the decay dataset. Radionuclide strings are parsed to to Ab-XX format.
-
-    Parameters
-    ----------
-    inv_dict : dict
-        Dictionary containing radionuclide strings as keys and activities as values.
-    radionuclides : List[str]
-        List of all the radionuclides in the decay dataset.
-    dataset : str
-        Name of the decay dataset.
-
-    Returns
-    -------
-    dict
-        Dictionary where the contents have been validated and the radionuclide key strings have
-        been parsed into symbol - mass number format.
-
-    Raises
-    ------
-    ValueError
-        If an activity key is invalid.
-
-    Examples
-    --------
-    >>> rd.utils.check_dictionary({'3H': 1.0}, rd.DEFAULTDATA.radionuclides, rd.DEFAULTDATA.dataset)
-    {'H-3': 1.0}
-
-
-    """
-
-    inv_dict = {
-        parse_radionuclide(nuc, radionuclides, dataset): act
-        for nuc, act in inv_dict.items()
-    }
-    for nuc, act in inv_dict.items():
-        if not isinstance(act, (float, int)):
-            raise ValueError(
-                str(act) + " is not a valid radioactivity for " + str(nuc) + "."
-            )
-
-    return inv_dict
-
-
 def time_unit_conv(
     time_period: float, units_from: str, units_to: str, year_conv: float
 ) -> float:
@@ -197,6 +149,7 @@ def time_unit_conv(
     """
 
     conv = {
+        "ps": 1.0e-12,
         "ns": 1.0e-9,
         "us": 1.0e-6,
         "ms": 1.0e-3,

--- a/radioactivedecay/utils.py
+++ b/radioactivedecay/utils.py
@@ -12,9 +12,10 @@ The examples shown assume the ``radioactivedecay`` package has been imported as:
 """
 
 from functools import singledispatch, update_wrapper
+from typing import Dict, List
 
 
-def parse_nuclide(nuclide):
+def parse_nuclide(nuclide: str) -> str:
     """
     Parses a nuclide string from XXAb or AbXX format to Ab-XX format. Not this function works for
     both radioactive and stable nuclides.
@@ -64,7 +65,9 @@ def parse_nuclide(nuclide):
     return nuclide
 
 
-def parse_radionuclide(radionuclide, radionuclides, dataset):
+def parse_radionuclide(
+    radionuclide: str, radionuclides: List[str], dataset: str
+) -> str:
     """
     Parses a radionuclide string and checks whether the radionuclide is contained in the decay
     dataset.
@@ -73,8 +76,8 @@ def parse_radionuclide(radionuclide, radionuclides, dataset):
     ----------
     radionuclide : str
         Radionuclide string.
-    radionuclides : numpy.ndarray
-        NumPy array of all the radionuclides in the decay dataset.
+    radionuclides : List[str]
+        List of all the radionuclides in the decay dataset.
     dataset : str
         Name of the decay dataset.
 
@@ -111,17 +114,19 @@ def parse_radionuclide(radionuclide, radionuclides, dataset):
     return radionuclide
 
 
-def check_dictionary(inv_dict, radionuclides, dataset):
+def check_dictionary(
+    inv_dict: Dict[str, float], radionuclides: List[str], dataset: str
+) -> Dict[str, float]:
     """
     Checks validity of a dictionary of radionuclides and associated acitivities. Radionuclides
-    must be in the decay dataset.
+    must be in the decay dataset. Radionuclide strings are parsed to to Ab-XX format.
 
     Parameters
     ----------
     inv_dict : dict
         Dictionary containing radionuclide strings as keys and activities as values.
-    radionuclides : numpy.ndarray
-        NumPy array of all the radionuclides in the decay dataset.
+    radionuclides : List[str]
+        List of all the radionuclides in the decay dataset.
     dataset : str
         Name of the decay dataset.
 
@@ -157,25 +162,27 @@ def check_dictionary(inv_dict, radionuclides, dataset):
     return inv_dict
 
 
-def time_unit_conv(time, units_from, units_to, year_conv):
+def time_unit_conv(
+    time_period: float, units_from: str, units_to: str, year_conv: float
+) -> float:
     """
-    Converts a time from one set of units to another.
+    Converts a time period from one time unit to another.
 
     Parameters
     ----------
-    time : float
-        Time before conversion.
+    time_period : float
+        Time period before conversion.
     units_from : str
         Time unit before conversion
     units_to : str
         Time unit after conversion
-    yeav_conv : float or int
+    yeav_conv : float
         Conversion factor for number of days in a year.
 
     Returns
     -------
     float
-        Time in new units.
+        Time period in new units.
 
     Raises
     ------
@@ -225,10 +232,12 @@ def time_unit_conv(time, units_from, units_to, year_conv):
             str(units_to) + ' is not a valid unit, e.g. "s", "m", "h", "d" or "y".'
         )
 
-    return time * conv[units_from] / conv[units_to]
+    return time_period * conv[units_from] / conv[units_to]
 
 
-def add_dictionaries(dict1, dict2):
+def add_dictionaries(
+    dict1: Dict[str, float], dict2: Dict[str, float]
+) -> Dict[str, float]:
     """
     Adds together two dictionaries of radionuclies and associated acitivities.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="radioactivedecay",
-    version="0.0.8",
+    version="0.0.9",
     author="Alex Malins",
     author_email="radioactivedecay@REMOVETHISalexmalins.com",
     license="MIT",
@@ -19,6 +19,8 @@ setuptools.setup(
         "Source Code": "https://github.com/alexmalins/radioactivedecay",
     },
     classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/test_decaydata.py
+++ b/tests/test_decaydata.py
@@ -18,7 +18,7 @@ class Test(unittest.TestCase):
 
         data = decaydata.DecayData("icrp107")
         self.assertEqual(data.dataset, "icrp107")
-        self.assertEqual(data.no_radionuclides, 1252)
+        self.assertEqual(data.num_radionuclides, 1252)
         self.assertEqual(data.year_conv, 365.2422)
         self.assertEqual(data.radionuclides[0], "Fm-257")
         self.assertEqual(data.radionuclides[-1], "H-3")
@@ -39,7 +39,7 @@ class Test(unittest.TestCase):
         # check instantiations with supplied dataset path
         data = decaydata.DecayData("icrp107_2", icrp107.__path__[0])
         self.assertEqual(data.dataset, "icrp107_2")
-        self.assertEqual(data.no_radionuclides, 1252)
+        self.assertEqual(data.num_radionuclides, 1252)
         self.assertEqual(data.year_conv, 365.2422)
         self.assertEqual(data.radionuclides[0], "Fm-257")
         self.assertEqual(data.radionuclides[-1], "H-3")

--- a/tests/test_decaydata.py
+++ b/tests/test_decaydata.py
@@ -65,7 +65,7 @@ class Test(unittest.TestCase):
         data = decaydata.DecayData("icrp107")
         self.assertEqual(data.half_life("H-3", "y"), 12.32)
 
-    def test_radionuclide_branching_fraction(self):
+    def test_decaydata_branching_fraction(self):
         """
         Test DecayData branching_fraction() method.
         """
@@ -74,7 +74,7 @@ class Test(unittest.TestCase):
         self.assertEqual(data.branching_fraction("K-40", "Ca-40"), 0.8914)
         self.assertEqual(data.branching_fraction("K-40", "H-3"), 0.0)
 
-    def test_radionuclide_decay_mode(self):
+    def test_decaydata_decay_mode(self):
         """
         Test DecayData decay_mode() method.
         """
@@ -90,6 +90,25 @@ class Test(unittest.TestCase):
 
         data = decaydata.DecayData("icrp107")
         self.assertEqual(data.__repr__(), "Decay dataset: icrp107")
+
+    def test_decaydata___eq__(self):
+        """
+        Test DecayData equality.
+        """
+
+        data1 = decaydata.DecayData("icrp107")
+        data2 = decaydata.DecayData("icrp107")
+        self.assertEqual(data1, data2)
+
+    def test_decaydata___ne__(self):
+        """
+        Test DecayData not equality.
+        """
+
+        data1 = decaydata.DecayData("icrp107")
+        data2 = decaydata.DecayData("icrp107")
+        data2.dataset = "icrp07"
+        self.assertNotEqual(data1, data2)
 
 
 if __name__ == "__main__":

--- a/tests/test_decayfunctions.py
+++ b/tests/test_decayfunctions.py
@@ -53,6 +53,16 @@ class Test(unittest.TestCase):
         inv = rd.Inventory({"Tc-99m": 2.3, "I-123": 5.8})
         self.assertEqual(inv.activities, [5.8, 2.3])
 
+    def test_inventory___len__(self):
+        """
+        Test len() on Inventory.
+        """
+
+        inv = rd.Inventory({"H-3": 1})
+        self.assertEqual(len(inv), 1)
+        inv = rd.Inventory({"Tc-99m": 2.3, "I-123": 5.8})
+        self.assertEqual(len(inv), 2)
+
     def test_inventory_add(self):
         """
         Test Inventory add() method to append to an inventory.

--- a/tests/test_decayfunctions.py
+++ b/tests/test_decayfunctions.py
@@ -250,18 +250,10 @@ class Test(unittest.TestCase):
         Test instantiation of Radionuclide objects.
         """
 
-        nuc = rd.Radionuclide("H-3")
-        self.assertEqual(nuc.radionuclide, "H-3")
-
-    def test_radionuclide_change(self):
-        """
-        Test Radionuclide change() method.
-        """
-
-        nuc = rd.Radionuclide("H-3")
-        nuc.change("Rn-222", rd.DEFAULTDATA)
+        nuc = rd.Radionuclide("Rn-222")
         self.assertEqual(nuc.radionuclide, "Rn-222")
         self.assertEqual(nuc.decay_constant, 2.0982180755947176e-06)
+        self.assertEqual(nuc.prog_bf_mode, {"Po-218": [1.0, "\u03b1"]})
 
     def test_radionuclide_half_life(self):
         """

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,5 +1,5 @@
 """
-Unit tests for decayfunctions.py functions, classes and methods.
+Unit tests for inventory.py functions, classes and methods.
 """
 
 import copy
@@ -11,8 +11,6 @@ class Test(unittest.TestCase):
     """
     Unit tests for decayfunctions.py functions, classes and methods.
     """
-
-    # pylint: disable=too-many-public-methods
 
     def test_inventory_instantiation(self):
         """
@@ -244,59 +242,6 @@ class Test(unittest.TestCase):
         self.assertEqual(
             inv.__repr__(), "Inventory: {'H-3': 10.0}, Decay dataset: icrp107"
         )
-
-    def test_radionuclide_instantiation(self):
-        """
-        Test instantiation of Radionuclide objects.
-        """
-
-        nuc = rd.Radionuclide("Rn-222")
-        self.assertEqual(nuc.radionuclide, "Rn-222")
-        self.assertEqual(nuc.decay_constant, 2.0982180755947176e-06)
-        self.assertEqual(nuc.prog_bf_mode, {"Po-218": [1.0, "\u03b1"]})
-
-    def test_radionuclide_half_life(self):
-        """
-        Test Radionuclide half_life() method.
-        """
-
-        nuc = rd.Radionuclide("H-3")
-        self.assertEqual(nuc.half_life("y"), 12.32)
-
-    def test_radionuclide_progeny(self):
-        """
-        Test Radionuclide half_life() method.
-        """
-
-        nuc = rd.Radionuclide("K-40")
-        self.assertEqual(nuc.progeny()[0], "Ca-40")
-        self.assertEqual(nuc.progeny()[1], "Ar-40")
-
-    def test_radionuclide_branching_fractions(self):
-        """
-        Test Radionuclide branching_fractions() method.
-        """
-
-        nuc = rd.Radionuclide("K-40")
-        self.assertEqual(nuc.branching_fractions()[0], 0.8914)
-        self.assertEqual(nuc.branching_fractions()[1], 0.1086)
-
-    def test_radionuclide_decay_modes(self):
-        """
-        Test Radionuclide decay_modes() method.
-        """
-
-        nuc = rd.Radionuclide("K-40")
-        self.assertEqual(nuc.decay_modes()[0], "\u03b2-")
-        self.assertEqual(nuc.decay_modes()[1], "\u03b2+ & EC")
-
-    def test_radionuclide___repr__(self):
-        """
-        Test Radionuclide representations.
-        """
-
-        nuc = rd.Radionuclide("H-3")
-        self.assertEqual(nuc.__repr__(), "Radionuclide: H-3, Decay dataset: icrp107")
 
 
 if __name__ == "__main__":

--- a/tests/test_radionuclide.py
+++ b/tests/test_radionuclide.py
@@ -3,7 +3,7 @@ Unit tests for radionuclide.py functions, classes and methods.
 """
 
 import unittest
-import radioactivedecay as rd
+from radioactivedecay import Radionuclide, DecayData
 
 
 class Test(unittest.TestCase):
@@ -16,7 +16,7 @@ class Test(unittest.TestCase):
         Test instantiation of Radionuclide objects.
         """
 
-        nuc = rd.Radionuclide("Rn-222")
+        nuc = Radionuclide("Rn-222")
         self.assertEqual(nuc.radionuclide, "Rn-222")
         self.assertEqual(nuc.decay_constant, 2.0982180755947176e-06)
         self.assertEqual(nuc.prog_bf_mode, {"Po-218": [1.0, "\u03b1"]})
@@ -26,7 +26,7 @@ class Test(unittest.TestCase):
         Test Radionuclide half_life() method.
         """
 
-        nuc = rd.Radionuclide("H-3")
+        nuc = Radionuclide("H-3")
         self.assertEqual(nuc.half_life("y"), 12.32)
 
     def test_radionuclide_progeny(self):
@@ -34,7 +34,7 @@ class Test(unittest.TestCase):
         Test Radionuclide half_life() method.
         """
 
-        nuc = rd.Radionuclide("K-40")
+        nuc = Radionuclide("K-40")
         self.assertEqual(nuc.progeny()[0], "Ca-40")
         self.assertEqual(nuc.progeny()[1], "Ar-40")
 
@@ -43,7 +43,7 @@ class Test(unittest.TestCase):
         Test Radionuclide branching_fractions() method.
         """
 
-        nuc = rd.Radionuclide("K-40")
+        nuc = Radionuclide("K-40")
         self.assertEqual(nuc.branching_fractions()[0], 0.8914)
         self.assertEqual(nuc.branching_fractions()[1], 0.1086)
 
@@ -52,7 +52,7 @@ class Test(unittest.TestCase):
         Test Radionuclide decay_modes() method.
         """
 
-        nuc = rd.Radionuclide("K-40")
+        nuc = Radionuclide("K-40")
         self.assertEqual(nuc.decay_modes()[0], "\u03b2-")
         self.assertEqual(nuc.decay_modes()[1], "\u03b2+ & EC")
 
@@ -61,8 +61,39 @@ class Test(unittest.TestCase):
         Test Radionuclide representations.
         """
 
-        nuc = rd.Radionuclide("H-3")
-        self.assertEqual(nuc.__repr__(), "Radionuclide: H-3, Decay dataset: icrp107")
+        nuc = Radionuclide("H-3")
+        self.assertEqual(nuc.__repr__(), "Radionuclide: H-3, decay dataset: icrp107")
+
+    def test_radionuclide___eq__(self):
+        """
+        Test Radionuclide equality.
+        """
+
+        nuc1 = Radionuclide("K-40")
+        nuc2 = Radionuclide("40K")
+        self.assertEqual(nuc1, nuc2)
+
+        data = DecayData("icrp107")
+        nuc2 = Radionuclide("K-40", data)
+        self.assertEqual(nuc1, nuc2)
+
+    def test_radionuclide___ne__(self):
+        """
+        Test Radionuclide not equality.
+        """
+
+        nuc1 = Radionuclide("K-40")
+        nuc2 = Radionuclide("H-3")
+        self.assertNotEqual(nuc1, nuc2)
+
+    def test_radionuclide___hash__(self):
+        """
+        Test Radionuclide hash function.
+        """
+
+        nuc = Radionuclide("K-40")
+        data = DecayData("icrp107")
+        self.assertEqual(hash(nuc), hash(("K-40", data.dataset)))
 
 
 if __name__ == "__main__":

--- a/tests/test_radionuclide.py
+++ b/tests/test_radionuclide.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for radionuclide.py functions, classes and methods.
+"""
+
+import unittest
+import radioactivedecay as rd
+
+
+class Test(unittest.TestCase):
+    """
+    Unit tests for decayfunctions.py functions, classes and methods.
+    """
+
+    def test_radionuclide_instantiation(self):
+        """
+        Test instantiation of Radionuclide objects.
+        """
+
+        nuc = rd.Radionuclide("Rn-222")
+        self.assertEqual(nuc.radionuclide, "Rn-222")
+        self.assertEqual(nuc.decay_constant, 2.0982180755947176e-06)
+        self.assertEqual(nuc.prog_bf_mode, {"Po-218": [1.0, "\u03b1"]})
+
+    def test_radionuclide_half_life(self):
+        """
+        Test Radionuclide half_life() method.
+        """
+
+        nuc = rd.Radionuclide("H-3")
+        self.assertEqual(nuc.half_life("y"), 12.32)
+
+    def test_radionuclide_progeny(self):
+        """
+        Test Radionuclide half_life() method.
+        """
+
+        nuc = rd.Radionuclide("K-40")
+        self.assertEqual(nuc.progeny()[0], "Ca-40")
+        self.assertEqual(nuc.progeny()[1], "Ar-40")
+
+    def test_radionuclide_branching_fractions(self):
+        """
+        Test Radionuclide branching_fractions() method.
+        """
+
+        nuc = rd.Radionuclide("K-40")
+        self.assertEqual(nuc.branching_fractions()[0], 0.8914)
+        self.assertEqual(nuc.branching_fractions()[1], 0.1086)
+
+    def test_radionuclide_decay_modes(self):
+        """
+        Test Radionuclide decay_modes() method.
+        """
+
+        nuc = rd.Radionuclide("K-40")
+        self.assertEqual(nuc.decay_modes()[0], "\u03b2-")
+        self.assertEqual(nuc.decay_modes()[1], "\u03b2+ & EC")
+
+    def test_radionuclide___repr__(self):
+        """
+        Test Radionuclide representations.
+        """
+
+        nuc = rd.Radionuclide("H-3")
+        self.assertEqual(nuc.__repr__(), "Radionuclide: H-3, Decay dataset: icrp107")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ import unittest
 from radioactivedecay.utils import (
     parse_nuclide,
     parse_radionuclide,
-    check_dictionary,
     time_unit_conv,
     add_dictionaries,
 )
@@ -107,45 +106,6 @@ class Test(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_radionuclide("Pbo-198m", radionuclides, dataset)
 
-    def test_check_dictionary(self):
-        """
-        Test the checking of inventory dictionaries.
-        """
-
-        radionuclides = ["H-3", "C-14"]
-        dataset = "test"
-
-        # Dictionary parsing
-        self.assertEqual(
-            check_dictionary({"H-3": 1.0}, radionuclides, dataset), {"H-3": 1.0}
-        )
-        self.assertEqual(
-            check_dictionary({"H3": 1.0}, radionuclides, dataset), {"H-3": 1.0}
-        )
-        self.assertEqual(
-            check_dictionary({"3H": 1.0}, radionuclides, dataset), {"H-3": 1.0}
-        )
-        self.assertEqual(
-            check_dictionary({"H-3": 1}, radionuclides, dataset), {"H-3": 1}
-        )
-        self.assertEqual(
-            check_dictionary({"H-3": 1}, radionuclides, dataset), {"H-3": 1.0}
-        )
-        self.assertEqual(
-            check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, dataset),
-            {"H-3": 1.0, "C-14": 2.0},
-        )
-        self.assertEqual(
-            check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, dataset),
-            {"C-14": 2.0, "H-3": 1.0},
-        )
-
-        # Catch incorrect arguments
-        with self.assertRaises(ValueError):
-            check_dictionary({"H-3": "1.0"}, radionuclides, dataset)
-        with self.assertRaises(ValueError):
-            check_dictionary({"1.0": "H-3"}, radionuclides, dataset)
-
     def test_time_unit_conv_seconds(self):
         """
         Test function which converts between seconds and different time units.
@@ -154,6 +114,9 @@ class Test(unittest.TestCase):
         yconv = 365.2422
 
         self.assertEqual(time_unit_conv(1.0, "s", "s", yconv), 1.0e0)
+        self.assertAlmostEqual(
+            time_unit_conv(1.0, "s", "ps", yconv), 1.0e12, places=(15 - 12)
+        )
         self.assertAlmostEqual(
             time_unit_conv(1.0, "s", "ns", yconv), 1.0e9, places=(15 - 9)
         )
@@ -164,6 +127,9 @@ class Test(unittest.TestCase):
         self.assertEqual(time_unit_conv(1.0, "s", "d", yconv), 1.0 / (60.0 ** 2 * 24.0))
         self.assertEqual(
             time_unit_conv(1.0, "s", "y", yconv), 1.0 / (60.0 ** 2 * 24.0 * 365.2422),
+        )
+        self.assertAlmostEqual(
+            time_unit_conv(1.0, "ps", "s", yconv), 1.0e-12, places=(12 + 15)
         )
         self.assertAlmostEqual(
             time_unit_conv(1.0, "ns", "s", yconv), 1.0e-9, places=(9 + 15)


### PR DESCRIPTION
Release alpha 0.0.9:

- Add support for using `Radionuclide` objects in place of radionuclide strings for `Inventory`
constructor, `add()` and `remove()` methods.
- Add `Radionuclide` `__hash__()` method (needed for above change).
- Add `half_lives()`, `progeny()`, `branching_fractions()` and `decay_modes()` methods to
`Inventory`.
- Add type hinting.
- Add support for calling `len()` on an `Inventory` to find the number of radionuclides it
contains.
- Add support for `==` and `!=` operators with `DecayData`, `Radionuclide` and `Inventory`
instances.
- Add support for `'ps'` (picoseconds) time unit.
- Code refactoring. `Radionuclide` and `Inventory` classes moved into separate files.
- In icrp107_dataset.ipynb, clarify that ICRP-107 does not contain data on spontaneous fission
outcomes.
- ReadMe and Docs updates (mainly updates of the theory and tutorial docpages).