### PR TITLE
Small ReadMe improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.X.X] - 2021-XX-XX
+- ReadMe: use `'readable'` for inv_t1 half-lives example.
+
 ## [0.2.3] - 2021-03-15
 - Improve `'readable'` half-life strings for radionuclides with half-lives less than 1 s or
 greater than 1000 years.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ and a trace amount of Tc-99. Plots are drawn using Matplotlib.
 in an ``Inventory``:
 
 ```pycon
->>> inv_t1.half_lives('d')
-{'Mo-99': 2.7475, 'Tc-99': 77102628.42, 'Tc-99m': 0.250625}
+>>> inv_t1.half_lives('readable')
+{'Mo-99': '65.94 h', 'Tc-99': '0.2111 My', 'Tc-99m': '6.015 h'}
 >>> inv_t1.progeny()
 {'Mo-99': ['Tc-99m', 'Tc-99'], 'Tc-99': ['Ru-99'], 'Tc-99m': ['Tc-99', 'Ru-99']}
 >>> inv_t1.branching_fractions()


### PR DESCRIPTION
Small ReadMe improvement

- ReadMe: use `'readable'` for inv_t1 half-lives example.