### PR TITLE
Add spelling variation half_life() method to Inventory class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## [0.X.X] - 2021-XX-XX
+## [0.2.4] - 2021-03-20
+- Add `Inventory.half_life()` method as spelling variation of `Inventory.half_lives()`
 - ReadMe: simplify. Use `'readable'` for inv_t1 half-lives example.
 
 ## [0.2.3] - 2021-03-15

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2021, Alex Malins"
 author = "Alex Malins"
 
 # The full version, including alpha/beta/rc tags
-release = "0.2.3"
+release = "0.2.4"
 
 
 # -- General configuration ---------------------------------------------------

--- a/radioactivedecay/__init__.py
+++ b/radioactivedecay/__init__.py
@@ -10,7 +10,7 @@ mode using SymPy routines which gives more accurate results for decay chains
 with orders of magnitude differences between radionuclide half-lives.
 """
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 from radioactivedecay.decaydata import DecayData, DEFAULTDATA
 from radioactivedecay.radionuclide import Radionuclide

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -688,6 +688,13 @@ class Inventory:
 
         return {nuc: self.data.half_life(nuc, units) for nuc in self.contents}
 
+    def half_life(self, units: str = "s") -> Dict[str, Union[float, str]]:
+        """
+        Same behaviour as half_lives() method.
+        """
+
+        return self.half_lives(units)
+
     def progeny(self) -> Dict[str, List[str]]:
         """
         Returns dictionary with the direct progeny of the radionuclides in the Inventory.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="radioactivedecay",
-    version="0.2.3",
+    version="0.2.4",
     author="Alex Malins",
     author_email="radioactivedecay@REMOVETHISalexmalins.com",
     license="MIT",

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -437,6 +437,16 @@ class Test(unittest.TestCase):
             inv.half_lives("readable"), {"C-14": "5.70 ky", "H-3": "12.32 y"}
         )
 
+    def test_inventory_half_life(self):
+        """
+        Test spelling variation of half_lives() method.
+        """
+
+        inv = Inventory({"C-14": 1.0, "H-3": 2.0})
+        self.assertEqual(inv.half_life("s"), inv.half_lives("s"))
+        self.assertEqual(inv.half_life("y"), inv.half_lives("y"))
+        self.assertEqual(inv.half_life("readable"), inv.half_lives("readable"))
+
     def test_inventory_progeny(self):
         """
         Test method to fetch progeny of radionuclides in the Inventory.


### PR DESCRIPTION
Add spelling variation half_life() method to Inventory class
- Add `Inventory.half_life()` method as spelling variation of `Inventory.half_lives()`