### PR TITLE
Document method for installing via conda.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [#.#.#] - ####-##-##
+- Document method for installing via conda.
+
 ## [0.3.3] - 2021-05-14
 - Improve readme and fix typo.
 - Add MANIFEST.in so LICENSE and markdown files get packaged.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,14 @@ the [Python Package Index](https://pypi.org/project/radioactivedecay/) using
 $ pip install radioactivedecay
 ```
 
-This command will also install the dependencies (Matplotlib, NetworkX, NumPy,
-SciPy & SymPy) if they are not already present in the environment.
+or from [conda-forge](https://anaconda.org/conda-forge/radioactivedecay):
+
+```console
+conda install -c conda-forge radioactivedecay
+```
+
+Either command will attempt to install the dependencies (Matplotlib, NetworkX,
+NumPy, SciPy & SymPy) if they are not already present in the environment.
 
 
 ## Usage
@@ -181,7 +187,7 @@ By default ``radioactivedecay`` uses decay data from
 (2008)](https://journals.sagepub.com/doi/pdf/10.1177/ANIB_38_3).
 
 The [notebooks
-folder](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks)
+directory](https://github.com/alexmalins/radioactivedecay/tree/main/notebooks)
 in the GitHub repository contains Jupyter Notebooks for creating the decay
 datasets that are read in by ``radioactivedecay``, e.g.
 [ICRP

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -18,19 +18,25 @@ installed from `python.org <https://www.python.org/>`_ and `PyPI
 Installation
 ------------
 
-The easiest way to install ``radioactivedecay`` is via the `Python Package
-Index <https://pypi.org/>`_ using ``pip``:
+The easiest ways to install ``radioactivedecay`` are via the `Python Package
+Index <https://pypi.org/project/radioactivedecay/>`_ using ``pip``:
 
 .. code-block:: bash
 
     $ pip install radioactivedecay
 
-This command will also attempt to install Matplotlib, NetworkX, NumPy, SciPy
-and SymPy if they are missing from your Python environment.
+or via `conda-forge <https://anaconda.org/conda-forge/radioactivedecay>`_:
+
+.. code-block:: bash
+
+    $ conda install -c conda-forge radioactivedecay
+
+Either command will attempt to install the dependencies (Matplotlib, NetworkX,
+NumPy, SciPy & SymPy) if they are not already present in the environment.
 
 It is also possible to clone the GitHub `repository 
 <https://github.com/alexmalins/radioactivedecay>`_ and install from within the
-``radioactivedecay`` folder using:
+``radioactivedecay`` directory using:
 
 .. code-block:: bash
 
@@ -39,8 +45,14 @@ It is also possible to clone the GitHub `repository
 Uninstallation
 --------------
 
-You can uninstall ``radioactivedecay`` with this command:
+You can uninstall ``radioactivedecay`` by:
 
 .. code-block:: bash
 
     $ pip uninstall radioactivedecay
+
+or if installed originally via ``conda``:
+
+.. code-block:: bash
+
+    $ conda uninstall radioactivedecay

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -22,14 +22,20 @@ platform independent and has been tested on Windows, MacOS and Linux systems.
 Quick Start
 -----------
 
-Install ``radioactivedecay`` via the command:
+Install ``radioactivedecay`` using ``pip`` by:
 
 .. code-block:: bash
 
     $ pip install radioactivedecay
-    
-This command will also attempt to install Matplotlib, NetworkX, NumPy, SciPy
-and SymPy if they are not already present in your environment.
+
+or using ``conda`` by:
+
+.. code-block:: bash
+
+    $ conda install -c conda-forge radioactivedecay
+
+Either command will attempt to install the dependencies (Matplotlib, NetworkX,
+NumPy, SciPy & SymPy) if they are not already present in the environment.
 
 Import the ``radioactivedecay`` package and decay a simple inventory using:
 
@@ -91,7 +97,7 @@ more details. It calls NumPy :ref:`[3] <refs>` and SciPy :ref:`[4] <refs>` for
 the matrix operations. There is also a high numerical precision decay
 calculation mode based on SymPy :ref:`[5] <refs>` routines.
 
-The `notebooks folder 
+The `notebooks directory 
 <https://github.com/alexmalins/radioactivedecay/tree/main/notebooks>`_ 
 in the GitHub repository contains some Jupyter Notebooks for creating the 
 `ICRP-107 decay dataset


### PR DESCRIPTION
- ``radioactivedecay`` can now be installed using Anaconda via the [conda-forge](https://anaconda.org/conda-forge/radioactivedecay) channel. Thanks for the suggestion @epassaro (#26).
- Replace instances of _folder_ with _directory_ in the documentation.