### PR TITLE
Change Inventory class contents and API to allow for number, activity, and mass IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ Create an ``Inventory`` of radionuclides and decay it as follows:
 >>> import radioactivedecay as rd
 >>> inv_t0 = rd.Inventory({'Mo-99': 2.0})
 >>> inv_t1 = inv_t0.decay(20.0, 'h')
->>> inv_t1.contents
+>>> inv_t1.activities()
 {'Mo-99': 1.6207863893776937,
-'Tc-99': 9.05304236308454e-09,
-'Tc-99m': 1.3719829376710406}
+ 'Ru-99': 0.0, 
+ 'Tc-99': 9.05304236308454e-09,
+ 'Tc-99m': 1.3719829376710406}
 ```
 
 An ``Inventory`` of 2.0 Bq of Mo-99 was decayed for 20 hours, producing the
@@ -75,6 +76,34 @@ Radionuclides can be specified in three equivalent ways in
 * ``'Ir-192n'``, ``'Ir192n'`` or ``'192nIr'``
 
 are all equivalent ways of specifying <sup>222</sup>Rn or <sup>192n</sup>Ir.
+
+Additional options for inputs and outputs include masses and numbers of atoms,
+using the ``input_type`` argument and ``numbers()``, ``masses()``,
+``mass_abundances()``, and ``moles()`` methods. 
+
+.. code-block:: python3
+
+    >>> inv_mass_t0 = rd.Inventory({'H-3': 3.2}, input_type="masses")
+    >>> inv_mass_t1 = inv_mass_t0.decay(12.32, 'y')
+    >>> inv_mass_t1.masses()
+    {'H-3': 1.6000000000000003, 'He-3': 1.5999894116584246}
+
+    >>> inv_num_t0 = rd.Inventory({'C-14': 3.2E24}, input_type="numbers")
+    >>> inv_num_t1 = inv_num_t0.decay(3000, 'y')
+    >>> inv_num_t1.moles()
+    {'C-14': 3.6894551567795797, 'N-14': 1.6242698581767292}
+
+Mass follows slightly stricter rules for units: mass in grams, with the added
+ability to input mass abundances using an inventory with masses summing to 1.0:
+
+.. code-block:: python3
+
+    >>> inv_abund_t0 = rd.Inventory({'Ni-56': .8, 'Co-56': .2}, input_type="masses")
+    >>> inv_abund_t1 = inv_abund_t0.decay(35.0, 'd')
+    >>> inv_abund_t1.mass_abundances()
+    {'Co-56': 0.7643201942234104,
+     'Fe-56': 0.2209301066281599,
+     'Ni-56': 0.014749699148429682}
 
 
 ### Plotting decay graphs
@@ -145,27 +174,28 @@ short-lived radionuclides:
 ```pycon
 >>> inv_t0 = rd.Inventory({'U-238': 1.0})
 >>> inv_t1 = inv_t0.decay_high_precision(10.0, 'd')
->>> inv_t1.contents
+>>> inv_t1.activities()
 {'At-218': 1.4511675857141352e-25,
-'Bi-210': 1.8093327888942224e-26,
-'Bi-214': 7.09819414496093e-22,
-'Hg-206': 1.9873081129046843e-33,
-'Pa-234': 0.00038581180879502017,
-'Pa-234m': 0.24992285949158477,
-'Pb-210': 1.0508864357335218e-25,
-'Pb-214': 7.163682655782086e-22,
-'Po-210': 1.171277829871092e-28,
-'Po-214': 7.096704966148592e-22,
-'Po-218': 7.255923469955255e-22,
-'Ra-226': 2.6127168262000313e-21,
-'Rn-218': 1.4511671865210924e-28,
-'Rn-222': 7.266530698712501e-22,
-'Th-230': 8.690585458641225e-16,
-'Th-234': 0.2499481473619856,
-'Tl-206': 2.579902288672889e-32,
-'Tl-210': 1.4897029111914831e-25,
-'U-234': 1.0119788393651999e-08,
-'U-238': 0.9999999999957525}
+ 'Bi-210': 1.8093327888942224e-26,
+ 'Bi-214': 7.09819414496093e-22,
+ 'Hg-206': 1.9873081129046843e-33,
+ 'Pa-234': 0.00038581180879502017,
+ 'Pa-234m': 0.24992285949158477,
+ 'Pb-206': 0.0,
+ 'Pb-210': 1.0508864357335218e-25,
+ 'Pb-214': 7.163682655782086e-22,
+ 'Po-210': 1.171277829871092e-28,
+ 'Po-214': 7.096704966148592e-22,
+ 'Po-218': 7.255923469955255e-22,
+ 'Ra-226': 2.6127168262000313e-21,
+ 'Rn-218': 1.4511671865210924e-28,
+ 'Rn-222': 7.266530698712501e-22,
+ 'Th-230': 8.690585458641225e-16,
+ 'Th-234': 0.2499481473619856,
+ 'Tl-206': 2.579902288672889e-32,
+ 'Tl-210': 1.4897029111914831e-25,
+ 'U-234': 1.0119788393651999e-08,
+ 'U-238': 0.9999999999957525}
 ```
 
 ## How radioactivedecay works

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -46,7 +46,7 @@ Import the ``radioactivedecay`` package and decay a simple inventory using:
     >>> import radioactivedecay as rd
     >>> inv_t0 = rd.Inventory({'H-3': 10.0})
     >>> inv_t1 = inv_t0.decay(12.32, 'y')
-    >>> inv_t1.contents
+    >>> inv_t1.activities()
     {'H-3': 5.0}
 
 Here we created an inventory of 10.0 units of tritium (:sup:`3`\H) and decayed
@@ -57,6 +57,35 @@ as 12.32 years is the half-life of tritium.
 same as the input units. The above example could therefore represent 10.0 Bq of
 tritium decaying to 5.0 Bq, or 10.0 Ci to 5.0 Ci, or whichever activity unit
 you prefer.
+
+Additional options for inputs and outputs include masses and numbers of atoms,
+using the ``input_type`` argument and ``numbers()``, ``masses()``,
+``mass_abundances()``, and ``moles()`` methods. 
+
+.. code-block:: python3
+
+    >>> inv_mass_t0 = rd.Inventory({'H-3': 3.2}, input_type="masses")
+    >>> inv_mass_t1 = inv_mass_t0.decay(12.32, 'y')
+    >>> inv_mass_t1.masses()
+    {'H-3': 1.6000000000000003, 'He-3': 1.5999894116584246}
+
+    >>> inv_num_t0 = rd.Inventory({'C-14': 3.2E24}, input_type="numbers")
+    >>> inv_num_t1 = inv_num_t0.decay(3000, 'y')
+    >>> inv_num_t1.moles()
+    {'C-14': 3.6894551567795797, 'N-14': 1.6242698581767292}
+
+Mass follows slightly stricter rules for units: mass in grams, with the added
+ability to input mass abundances using an inventory with masses summing to 1.0:
+
+.. code-block:: python3
+
+    >>> inv_abund_t0 = rd.Inventory({'Ni-56': .8, 'Co-56': .2}, input_type="masses")
+    >>> inv_abund_t1 = inv_abund_t0.decay(35.0, 'd')
+    >>> inv_abund_t1.mass_abundances()
+    {'Co-56': 0.7643201942234104,
+     'Fe-56': 0.2209301066281599,
+     'Ni-56': 0.014749699148429682}
+
 
 Use the ``plot()`` method to show the decay of the inventory over time:
 

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -76,10 +76,21 @@ to ``decay()``. :math:`e^{\varLambda_{d} t}` is the matrix exponential of
 :math:`\varLambda_{d} t`. It is a diagonal matrix with elements
 :math:`e^{\varLambda_{d} t}_{ii} = e^{-\lambda_i t}`. 
 
-The final equation that is needed is the conversion between the activity
-(:math:`\mathbf{A}`) and number of atoms (:math:`\mathbf{N}`) vectors.
-:math:`\mathbf{A}` is just an element-wise multiplication of the decay constants
-and the number of atoms:
+The final equations that are needed are the conversions between the various
+input and output types and the numbers of each atom in the initial number of 
+atoms (:math:`\mathbf{N}`) vector, which is done using element-wise
+algebra using the number of atoms.
+
+Converting between mass (:math:`\mathbf{M}`, in grams) and number of atoms
+(:math:`\mathbf{N}`) uses the vector of atomic masses (:math:`\mathbf{Ma}`) and
+the Avogadro constant (:math:`N_a`):
+
+.. math::
+    M_i =  \frac{Ma_i N_i}{N_a}.
+
+Converting between activity (:math:`\mathbf{A}`) and number of atoms
+(:math:`\mathbf{N}`) uses the vector of decay constants
+(:math:`\mathbf{\lambda}`):
 
 .. math::
     A_i = \lambda_i N_i.
@@ -112,33 +123,20 @@ e.g.
 .. code-block:: python3
 
     >>> inv = rd.Inventory({'Es-254': 1.0})
-    >>> inv.decay(0.0).contents
-    {'At-218': -8.24439035981494e-30,
-    'Bi-210': 2.5308844932098316e-26,
-    'Bi-214': -4.256549745172888e-26,
-    'Bk-250': 0.0,
-    'Cf-250': 0.0,
-    'Cm-246': 8.802967479989175e-21,
-    'Es-254': 1.0,
-    'Fm-254': 0.0,
-    'Hg-206': -3.4696439711117526e-34,
-    'Pa-234': 2.330729590281097e-29,
-    'Pa-234m': -1.5696690930108473e-26,
-    'Pb-210': 2.673060958594837e-26,
-    'Pb-214': -7.310828272597407e-27,
-    'Po-210': -1.048466176320909e-27,
-    'Po-214': 2.3260114484256133e-26,
-    'Po-218': -1.1433437709020225e-26,
-    'Pu-242': 1.3827905917787723e-22,
-    'Ra-226': -1.0811575068833228e-26,
-    'Rn-218': -1.618765025703667e-33,
-    'Rn-222': -1.581593359682259e-26,
-    'Th-230': -1.2628442466252288e-26,
-    'Th-234': -2.6140879622245746e-27,
-    'Tl-206': -4.332210492987691e-34,
-    'Tl-210': 2.2028710112960294e-31,
-    'U-234': -1.0389580591195201e-26,
-    'U-238': -8.466705440297454e-27}
+    >>> inv.decay(0.0).activities()
+    {'At-218': -8.24439035981494e-30, 'Bi-210': 2.5308844932098316e-26,
+     'Bi-214': -4.256549745172888e-26, 'Bk-250': 0.0, 'Cf-250': 0.0,
+     'Cm-246': 8.802967479989175e-21, 'Es-254': 1.0, 'Fm-254': 0.0,
+     'Hg-206': -3.4696439711117526e-34, 'Pa-234': 2.330729590281097e-29,
+     'Pa-234m': -1.5696690930108473e-26, 'Pb-206': 0.0,
+     'Pb-210': 2.673060958594837e-26, 'Pb-214': -7.310828272597407e-27,
+     'Po-210': -1.048466176320909e-27, 'Po-214': 2.3260114484256133e-26,
+     'Po-218': -1.1433437709020225e-26, 'Pu-242': 1.3827905917787723e-22,
+     'Ra-226': -1.0811575068833228e-26, 'Rn-218': -1.618765025703667e-33,
+     'Rn-222': -1.581593359682259e-26, 'Th-230': -1.2628442466252288e-26,
+     'Th-234': -2.6140879622245746e-27, 'Tl-206': -4.332210492987691e-34,
+     'Tl-210': 2.2028710112960294e-31, 'U-234': -1.0389580591195201e-26,
+     'U-238': -8.466705440297454e-27}
 
 All the progeny of Es-254 should have an activity of exactly zero for this
 calculation.
@@ -150,33 +148,16 @@ numerical precision is needed:
 .. code-block:: python3
 
     >>> inv = rd.Inventory({'Es-254': 1.0})
-    >>> inv.decay_high_precision(0.0).contents
-    {'At-218': 0.0,
-    'Bi-210': 0.0,
-    'Bi-214': 0.0,
-    'Bk-250': 0.0,
-    'Cf-250': 0.0,
-    'Cm-246': 0.0,
-    'Es-254': 1.0,
-    'Fm-254': 0.0,
-    'Hg-206': 0.0,
-    'Pa-234': 0.0,
-    'Pa-234m': 0.0,
-    'Pb-210': 0.0,
-    'Pb-214': 0.0,
-    'Po-210': 0.0,
-    'Po-214': 0.0,
-    'Po-218': 0.0,
-    'Pu-242': 0.0,
-    'Ra-226': 0.0,
-    'Rn-218': 0.0,
-    'Rn-222': 0.0,
-    'Th-230': 0.0,
-    'Th-234': 0.0,
-    'Tl-206': 0.0,
-    'Tl-210': 0.0,
-    'U-234': 0.0,
-    'U-238': 0.0}
+    >>> inv.decay_high_precision(0.0).activities()
+    {'At-218': 0.0, 'Bi-210': 0.0, 'Bi-214': 0.0,
+     'Bk-250': 0.0, 'Cf-250': 0.0, 'Cm-246': 0.0,
+     'Es-254': 1.0, 'Fm-254': 0.0, 'Hg-206': 0.0,
+     'Pa-234': 0.0, 'Pa-234m': 0.0, 'Pb-206': 0.0,
+     'Pb-210': 0.0, 'Pb-214': 0.0, 'Po-210': 0.0,
+     'Po-214': 0.0, 'Po-218': 0.0, 'Pu-242': 0.0,
+     'Ra-226': 0.0, 'Rn-218': 0.0, 'Rn-222': 0.0,
+     'Th-230': 0.0, 'Th-234': 0.0, 'Tl-206': 0.0,
+     'Tl-210': 0.0, 'U-234': 0.0,  'U-238': 0.0}
 
 The ``decay_high_precision()`` method carries exact SymPy expressions through
 decay calculations as far as is practicable. At the final step, the decayed

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -21,19 +21,48 @@ Create an inventory of radionuclides and associated activities as follows:
 
 This is an inventory of natural uranium.
 
-The following commands can be used to view the contents (the radionuclides and
-their activities) and decay data set associated with an inventory:
+The ``Inventory`` class keeps track of the number of atoms
+of each nuclide. The following commands can be used to convert the contents
+(the nuclides and their respective number of atoms) into activities, numbers,
+masses, or abundances, as well as return the decay data set associated with an
+inventory:
 
 .. code-block:: python3
 
-    >>> inv_t0.contents
+    >>> inv_t0.activities()
     {'U-234': 0.005, 'U-235': 0.72, 'U-238': 99.274}
     >>> inv_t0.radionuclides
     ['U-234', 'U-235', 'U-238']
-    >>> inv_t0.activities
-    [0.005, 0.72, 99.274]
+    >>> inv_t0.numbers():
+    {'U-234': 55884417984.51489, 'U-235': 2.3076736283495652e+16, 'U-238': 2.0193793783074922e+19}
+    >>> inv_t0.masses():
+    {'U-234': 2.1718592794623984e-11, 'U-235': 9.006841520909447e-06, 'U-238': 0.00798245788808877}
+    >>> inv_t0.mass_abundances():
+    {'U-234': 2.7177236552303014e-09, 'U-235': 0.0011270576547825488, 'U-238': 0.9988729396274937}
+    >>> inv_t0.moles():
+    {'U-234': 9.279825930955971e-14, 'U-235': 3.831982214161273e-08, 'U-238': 3.3532583491248255e-05}
     >>> inv_t0
-    Inventory: {'U-234': 0.005, 'U-235': 0.72, 'U-238': 99.274}, decay dataset: icrp107
+    Inventory: {'U-234': 55884417984.51489, 'U-235': 2.3076736283495652e+16, 'U-238': 2.0193793783074922e+19}, decay dataset: icrp107
+
+The input of ``Inventory`` is by default activity. The user can easily change
+the input using the ``input_type`` keyword argument during initialization: 
+
+.. code-block:: python3
+
+    # initialize an inventory using activities:
+    >>> inv1 = rd.Inventory({'U-238': 99.274, 'U-235': 0.720, 'U-234': 0.005})
+    >>> inv1.activities()
+    {'U-234': 0.005, 'U-235': 0.72, 'U-238': 99.274}
+    >>> inv1.numbers():
+    {'U-234': 55884417984.51489, 'U-235': 2.3076736283495652e+16, 'U-238': 2.0193793783074922e+19}
+    
+    # initialize an inventory using number of atoms:
+    >>> inv2 = rd.Inventory({'U-238': 2000, 'U-235': 3000, 'U-234': 1500}, input_type="numbers")
+    >>> inv2.activities()
+    {'U-234': 1.3420556696283726e-10, 'U-235': 9.360075764027427e-14, 'U-238': 9.832129719300668e-15}
+    >>> inv2.numbers():
+    {'U-234': 1500, 'U-235': 3000, 'U-238': 2000}
+
 
 Radioactive decay calculations
 ------------------------------
@@ -44,26 +73,26 @@ uranium inventory:
 .. code-block:: python3
 
     >>> inv_t1 = inv_t0.decay(1E9, 'y')
-    >>> inv_t1.contents
+    >>> inv_t1.activities()
     {'Ac-227': 0.2690006281740556, 'At-218': 0.017002868638497183,
      'At-219': 2.227325201281319e-07, 'Bi-210': 85.01434361515662,
      'Bi-211': 0.26900084425585846, 'Bi-214': 85.01432618961896,
      'Bi-215': 2.1605054452429237e-07, 'Fr-223': 0.0037122086688021884,
      'Hg-206': 1.6152725286830197e-06, 'Pa-231': 0.2690006198549055,
      'Pa-234': 0.13601313171698984, 'Pa-234m': 85.00820732310412,
-     'Pb-210': 85.01434361489548, 'Pb-211': 0.2690008442558569,
-     'Pb-214': 84.99734032384839, 'Po-210': 85.01434362236536,
-     'Po-211': 0.0007424423301461693, 'Po-214': 84.99649018398776,
-     'Po-215': 0.26900084425583065, 'Po-218': 85.01434319248591,
-     'Ra-223': 0.26900062820528614, 'Ra-226': 85.01434319228659,
-     'Rn-218': 1.7002868638497185e-05, 'Rn-219': 0.26900062820528614,
-     'Rn-222': 85.0143431924858, 'Th-227': 0.2652884195245263,
-     'Th-230': 85.01431274847525, 'Th-231': 0.26898810215560653,
-     'Th-234': 85.00820732310407, 'Tl-206': 0.00011383420610068998,
-     'Tl-207': 0.26825840192571576, 'Tl-210': 0.01785300849981999,
-     'U-234': 85.01287846492669, 'U-235': 0.2689881021544942,
-     'U-238': 85.00820732184867}
-    
+     'Pb-206': 0.0, 'Pb-207': 0.0, 'Pb-210': 85.01434361489548,
+     'Pb-211': 0.2690008442558569, 'Pb-214': 84.99734032384839,
+     'Po-210': 85.01434362236536, 'Po-211': 0.0007424423301461693,
+     'Po-214': 84.99649018398776, 'Po-215': 0.26900084425583065,
+     'Po-218': 85.01434319248591, 'Ra-223': 0.26900062820528614,
+     'Ra-226': 85.01434319228659, 'Rn-218': 1.7002868638497185e-05,
+     'Rn-219': 0.26900062820528614, 'Rn-222': 85.0143431924858,
+     'Th-227': 0.2652884195245263, 'Th-230': 85.01431274847525,
+     'Th-231': 0.26898810215560653, 'Th-234': 85.00820732310407,
+     'Tl-206': 0.00011383420610068998, 'Tl-207': 0.26825840192571576,
+     'Tl-210': 0.01785300849981999, 'U-234': 85.01287846492669,
+     'U-235': 0.2689881021544942, 'U-238': 85.00820732184867}
+        
 The ``decay()`` method takes two arguments: the decay time period and its
 units. Units can be entered using :code:`'ps'`, :code:`'ns'`, :code:`'us'`,
 :code:`'ms'`, :code:`'s'`, :code:`'m'`, :code:`'h'`, :code:`'d'`, :code:`'y'`,
@@ -85,25 +114,25 @@ with the ``decay()`` method.
 .. code-block:: python3
 
     >>> inv_t1 = inv_t0.decay_high_precision(1E9, 'y')
-    >>> inv_t1.contents
+    >>> inv_t1.activities()
     {'Ac-227': 0.26900062817405557, 'At-218': 0.01700286863849718,
     'At-219': 2.227325201281318e-07, 'Bi-210': 85.01434361515662,
     'Bi-211': 0.2690008442558584, 'Bi-214': 85.01432618961894,
     'Bi-215': 2.1605054452429227e-07, 'Fr-223': 0.003712208668802187,
     'Hg-206': 1.6152725286830195e-06, 'Pa-231': 0.2690006198549054,
     'Pa-234': 0.13601313171698984, 'Pa-234m': 85.00820732310412,
-    'Pb-210': 85.01434361489547, 'Pb-211': 0.26900084425585685,
-    'Pb-214': 84.99734032384836, 'Po-210': 85.01434362236536,
-    'Po-211': 0.0007424423301461693, 'Po-214': 84.99649018398776,
-    'Po-215': 0.26900084425583065, 'Po-218': 85.0143431924859,
-    'Ra-223': 0.2690006282052861, 'Ra-226': 85.0143431922866,
-    'Rn-218': 1.7002868638497178e-05, 'Rn-219': 0.26900062820528614,
-    'Rn-222': 85.01434319248578, 'Th-227': 0.26528841952452625,
-    'Th-230': 85.01431274847525, 'Th-231': 0.26898810215560653,
-    'Th-234': 85.00820732310407, 'Tl-206': 0.00011383420610068996,
-    'Tl-207': 0.2682584019257157, 'Tl-210': 0.017853008499819988,
-    'U-234': 85.01287846492669, 'U-235': 0.26898810215449415,
-    'U-238': 85.00820732184867}
+    'Pb-206': 0.0, 'Pb-207': 0.0, 'Pb-210': 85.01434361489547,
+    'Pb-211': 0.26900084425585685, 'Pb-214': 84.99734032384836,
+    'Po-210': 85.01434362236536, 'Po-211': 0.0007424423301461693,
+    'Po-214': 84.99649018398776, 'Po-215': 0.26900084425583065,
+    'Po-218': 85.0143431924859, 'Ra-223': 0.2690006282052861,
+    'Ra-226': 85.0143431922866, 'Rn-218': 1.7002868638497178e-05,
+    'Rn-219': 0.26900062820528614, 'Rn-222': 85.01434319248578,
+    'Th-227': 0.26528841952452625, 'Th-230': 85.01431274847525,
+    'Th-231': 0.26898810215560653, 'Th-234': 85.00820732310407,
+    'Tl-206': 0.00011383420610068996, 'Tl-207': 0.2682584019257157,
+    'Tl-210': 0.017853008499819988, 'U-234': 85.01287846492669,
+    'U-235': 0.26898810215449415, 'U-238': 85.00820732184867}
 
 Radionuclide name formatting and metastable states
 --------------------------------------------------
@@ -217,11 +246,20 @@ It is easy to add radionuclides to an ``Inventory`` using the ``add()`` method:
 .. code-block:: python3
 
     >>> inv = rd.Inventory({'H-3': 1.0, 'Be-10': 2.0})
-    >>> inv.contents
+    >>> inv.activities()
     {'Be-10': 2.0, 'H-3': 1.0}
     >>> inv.add({'C-14': 3.0, 'K-40': 4.0})
-    >>> inv.contents
+    >>> inv.activities()
     {'Be-10': 2.0, 'C-14': 3.0, 'H-3': 1.0, 'K-40': 4.0}
+
+Similarly, subtract radionuclides from an ``Inventory`` using the
+``subtract()`` method:
+
+.. code-block:: python3
+
+    >>> inv.subtract({'Be-10': 1.0, 'K-40': 2.0})
+    >>> inv.activities()
+    {'Be-10': 1.0, 'C-14': 3.0, 'H-3': 1.0, 'K-40': 2.0}
 
 Likewise use ``remove()`` to erase one or more radionuclide from an
 ``Inventory``:
@@ -229,11 +267,23 @@ Likewise use ``remove()`` to erase one or more radionuclide from an
 .. code-block:: python3
 
     >>> inv.remove('H-3')
-    >>> inv.contents
-    {'Be-10': 2.0, 'C-14': 3.0, 'K-40': 4.0}
+    >>> inv.activities()
+    {'Be-10': 1.0, 'C-14': 3.0, 'K-40': 2.0}
     >>> inv.remove(['Be-10', 'K-40'])
-    >>> inv.contents
+    >>> inv.activities()
     {'C-14': 3.0}
+
+The ``add()`` and ``subtract()`` methods also have the ``input_type`` argument
+for inputs other than activities, and mixing input types is allowed:
+
+.. code-block:: python3
+
+    >>> inv.add({'H-3': 1.3E9}, input_type="numbers")
+    >>> inv.activities()
+    {'C-14': 3.0, 'H-3': 2.3177330463306007}
+    >>> inv.subtract({'C-14': 7.1E-12}, input_type="masses")
+    >>> inv.activities()
+    {'C-14': 1.8233790683016682, 'H-3': 2.3177330463306007}
 
 You can also supply ``Radionuclide`` objects instead of strings to the
 ``Inventory`` constructor, and the ``add()`` and ``remove()`` methods:
@@ -242,14 +292,14 @@ You can also supply ``Radionuclide`` objects instead of strings to the
 
     >>> H3 = rd.Radionuclide('H-3')
     >>> inv = rd.Inventory({H3: 1.0})
-    >>> inv.contents
+    >>> inv.activities()
     {'H-3': 1.0}
     >>> Be10 = rd.Radionuclide('Be-10')
     >>> inv.add({Be10: 2.0})
-    >>> inv.contents
+    >>> inv.activities()
     {'Be-10': 2.0, 'H-3': 1.0}
     >>> inv.remove(H3)
-    >>> inv.contents
+    >>> inv.activities()
     {'Be-10': 2.0}
 
 Note if the decay dataset of the ``Radionuclide`` instance is different to that
@@ -264,10 +314,10 @@ inventory:
 
 .. code-block:: python3
 
-    >>> inv1 = rd.Inventory({'H-3': 1.0})
-    >>> inv2 = rd.Inventory({'C-14': 1.0})
+    >>> inv1 = rd.Inventory({'H-3': 1.0}, input_type="masses")
+    >>> inv2 = rd.Inventory({'C-14': 1.0}, input_type="masses")
     >>> inv = inv1 + inv2
-    >>> inv.contents
+    >>> inv.masses()
     {'C-14': 1.0, 'H-3': 1.0}
 
 It is also possible to subtract the contents of one inventory from another:
@@ -275,7 +325,7 @@ It is also possible to subtract the contents of one inventory from another:
 .. code-block:: python3
 
     >>> inv = inv - inv1
-    >>> inv.contents
+    >>> inv.masses()
     {'C-14': 1.0, 'H-3': 0.0}
 
 Multiplication and division on inventories
@@ -286,11 +336,11 @@ by a constant as follows:
 
 .. code-block:: python3
 
-    >>> inv = rd.Inventory({'Sr-90': 1.0, 'Cs-137': 1.0})
+    >>> inv = rd.Inventory({'Sr-90': 1.0, 'Cs-137': 1.0}, input_type="numbers")
     >>> inv = inv * 2
-    >>> inv.contents
+    >>> inv.numbers()
     {'Sr-90': 2.0, 'Cs-137': 2.0}
     >>> inv = inv / 2
-    >>> inv.contents
+    >>> inv.numbers()
     {'Sr-90': 1.0, 'Cs-137': 1.0} 
 

--- a/radioactivedecay/decaydata.py
+++ b/radioactivedecay/decaydata.py
@@ -269,6 +269,7 @@ class DecayData:
         self.radionuclides = data["radionuclides"]
         self.hldata = data["hldata"]
         self.prog_bfs_modes = data["prog_bfs_modes"]
+        self.masses = data["masses"]
 
         self.num_radionuclides = self.radionuclides.size
         self.radionuclide_dict = dict(

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -352,12 +352,12 @@ def _input_to_number(
     
     number_abundance_dict, number_dict = {}, {}
     
-    if input_type == "mass":
+    if input_type == "masses":
         for nuc, mass in input_inv_dict.items():
             number = _mass_to_number(nuc, mass, data)
             number_dict[nuc] = number
         converted_dict = number_dict.copy()
-    elif input_type == "activity":
+    elif input_type == "activities":
         for nuc, act in input_inv_dict.items():
             number = _activity_to_number(nuc, act, data)
             number_dict[nuc] = number
@@ -379,7 +379,7 @@ def _input_to_number(
 def _check_dictionary(
     input_inv_dict: Dict[Union[str, Radionuclide], float],
     radionuclides: List[str],
-    input_type: str = "activity",
+    input_type: str = "activities",
     data: DecayData = DEFAULTDATA
 ) -> Dict[str, float]:
     """
@@ -394,7 +394,7 @@ def _check_dictionary(
     radionuclides : List[str]
         List of all the radionuclides in the decay dataset.
     input_type : str, optional
-        Type of input (number, mass (abundance), or activity), default is activity.
+        Type of input (numbers, masses (abundance), or activities), default is activities.
     data : DecayData, optional
         Decay dataset (default is the ICRP-107 dataset).
 
@@ -411,10 +411,10 @@ def _check_dictionary(
 
     Examples
     --------
-    >>> rd.inventory._check_dictionary({'3H': 1.0}, rd.DEFAULTDATA.radionuclides, "number", rd.DEFAULTDATA.dataset)
+    >>> rd.inventory._check_dictionary({'3H': 1.0}, rd.DEFAULTDATA.radionuclides, "numbers", rd.DEFAULTDATA.dataset)
     {'H-3': 1.0}
     >>> H3 = rd.Radionuclide('H-3')
-    >>> rd.inventory._check_dictionary({H3: 1.0}, rd.DEFAULTDATA.radionuclides, "number", rd.DEFAULTDATA.dataset)
+    >>> rd.inventory._check_dictionary({H3: 1.0}, rd.DEFAULTDATA.radionuclides, "numbers", rd.DEFAULTDATA.dataset)
     {'H-3': 1.0}
 
     """
@@ -433,7 +433,7 @@ def _check_dictionary(
                 str(inp) + " is not a valid input for " + str(nuc) + "."
             )
 
-    if input_type != "number":
+    if input_type != "numbers":
         inv_dict = _input_to_number(parsed_inv_dict, input_type, data).copy()
     else:
         inv_dict = parsed_inv_dict.copy()
@@ -494,7 +494,7 @@ class Inventory:
         Dictionary containing radionuclide strings or Radionuclide objects as keys and numbers
         as values.
     input_type : str, optional
-        Type of input (abundance, number, activity; activity is default)
+        Type of input (masses, numbers, activities; activities is default)
     check : bool, optional
         Check for the validity of contents (default is True).
     data : DecayData, optional
@@ -515,7 +515,7 @@ class Inventory:
     >>> H3 = rd.Radionuclide('H-3')
     >>> rd.Inventory({H3: 3.0})
     Inventory: {'H-3': 1682678687.3382246}, decay dataset: icrp107
-    >>> rd.Inventory({'U-238': 21.1, 'Co-57': 7.2}, input_type="mass")
+    >>> rd.Inventory({'U-238': 21.1, 'Co-57': 7.2}, input_type="masses")
     Inventory: {'Co-57': 7.61542657764305e+22, 'U-238': 5.337817684684321e+22}, decay dataset: icrp107
 
     """
@@ -523,7 +523,7 @@ class Inventory:
     def __init__(
         self,
         input: Dict[Union[str, Radionuclide], float],
-        input_type: str = "activity",
+        input_type: str = "activities",
         check: bool = True,
         data: DecayData = DEFAULTDATA
     ) -> None:
@@ -671,12 +671,12 @@ class Inventory:
             Dictionary containing radionuclide strings or Radionuclide objects as keys and
             activities as values which are added to the Inventory.
         input_type : str, optional
-            Type of input, default is activity.
+            Type of input, default is activities.
 
         Examples
         --------
-        >>> inv = rd.Inventory({'H-3': 1.0}, "number")
-        >>> inv.add({'C-14': 2.0}, "number")
+        >>> inv = rd.Inventory({'H-3': 1.0}, "numbers")
+        >>> inv.add({'C-14': 2.0}, "numbers")
         >>> inv.contents()
         {'C-14': 2.0, 'H-3': 1.0}
 
@@ -686,12 +686,12 @@ class Inventory:
             add_contents, self.data.radionuclides, input_type, self.data
         )
         new_contents = _add_dictionaries(self.contents, parsed_add_contents)
-        self._change(new_contents, "number", False, self.data)
+        self._change(new_contents, "numbers", False, self.data)
 
     def subtract(
         self,
         sub_contents: Dict[Union[str, Radionuclide], float],
-        input_type: str = "activity"
+        input_type: str = "activities"
     ) -> None:
         """
         Subtracts a dictionary of radionuclides and associated numbers from this inventory.
@@ -704,8 +704,8 @@ class Inventory:
 
         Examples
         --------
-        >>> inv = rd.Inventory({'C-14': 2.0, 'H-3': 1.0}, "number")
-        >>> inv.subtract({'H-3': 1.0}, "number")
+        >>> inv = rd.Inventory({'C-14': 2.0, 'H-3': 1.0}, "numbers")
+        >>> inv.subtract({'H-3': 1.0}, "numbers")
         >>> inv.contents()
         {'C-14': 2.0, 'H-3': 0.0}
 
@@ -718,7 +718,7 @@ class Inventory:
             for nuclide, number in parsed_sub_contents.items()
         )
         new_contents = _add_dictionaries(self.contents, parsed_sub_contents)
-        self._change(new_contents, "number", False, self.data)
+        self._change(new_contents, "numbers", False, self.data)
 
     def __add__(self, other: "Inventory") -> "Inventory":
         """
@@ -733,7 +733,7 @@ class Inventory:
                 + other.data.dataset
             )
         new_contents = _add_dictionaries(self.contents, other.contents)
-        return Inventory(new_contents, "number", False, self.data)
+        return Inventory(new_contents, "numbers", False, self.data)
 
     def __sub__(self, other: "Inventory") -> "Inventory":
         """
@@ -753,7 +753,7 @@ class Inventory:
             for nuclide, number in sub_contents.items()
         )
         new_contents = _add_dictionaries(self.contents, sub_contents)
-        return Inventory(new_contents, "number", False, self.data)
+        return Inventory(new_contents, "numbers", False, self.data)
 
     def __mul__(self, const: float) -> "Inventory":
         """
@@ -764,7 +764,7 @@ class Inventory:
         new_contents = self.contents.copy()
         for nuclide, number in new_contents.items():
             new_contents[nuclide] = number * const
-        return Inventory(new_contents, "number", False, self.data)
+        return Inventory(new_contents, "numbers", False, self.data)
 
     def __rmul__(self, const: float) -> "Inventory":
         """
@@ -817,7 +817,7 @@ class Inventory:
         if delete not in new_contents:
             raise ValueError(delete + " does not exist in this inventory.")
         new_contents.pop(delete)
-        self._change(new_contents, "number", False, self.data)
+        self._change(new_contents, "numbers", False, self.data)
 
     @remove.register(Radionuclide)
     def _(
@@ -832,7 +832,7 @@ class Inventory:
         if delete not in new_contents:
             raise ValueError(delete + " does not exist in this inventory.")
         new_contents.pop(delete)
-        self._change(new_contents, "number", False, self.data)
+        self._change(new_contents, "numbers", False, self.data)
 
     @remove.register(list)
     def _(
@@ -853,7 +853,7 @@ class Inventory:
             if nuc not in new_contents:
                 raise ValueError(nuc + " does not exist in this inventory.")
             new_contents.pop(nuc)
-        self._change(new_contents, "number", False, self.data)
+        self._change(new_contents, "numbers", False, self.data)
 
     def decay(
         self, decay_time: float, units: str = "s", sig_fig: Union[None, int] = None
@@ -939,7 +939,7 @@ class Inventory:
             dict(zip(self.data.radionuclides[indices], vector_at))
         )
 
-        return Inventory(new_contents, "number", False, self.data)
+        return Inventory(new_contents, "numbers", False, self.data)
 
     def decay_high_precision(
         self, decay_time: float, units: str = "s", sig_fig: int = 320
@@ -1031,7 +1031,7 @@ class Inventory:
             new_contents[self.data.radionuclides[i]] = float(vector_nt[i, 0])
         new_contents = _sort_dictionary_alphabetically(new_contents)
 
-        return Inventory(new_contents, "number", False, self.data)
+        return Inventory(new_contents, "numbers", False, self.data)
 
     def half_lives(self, units: str = "s") -> Dict[str, Union[float, str]]:
         """

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -102,8 +102,9 @@ def _activity_to_number(
 
     try:
         index = data.radionuclide_dict[radionuclide]
-    except:
-        raise ValueError(radionuclide + " is not a valid member of " + data.dataset)
+    except BaseException:
+        raise ValueError(radionuclide + " is not a valid member of "
+                         + data.dataset)
 
     return activity / data.scipy_data.decay_consts[index]
 
@@ -137,8 +138,9 @@ def _mass_to_number(
 
     try:
         index = data.radionuclide_dict[radionuclide]
-    except:
-        raise ValueError(radionuclide + " is not a valid member of " + data.dataset)
+    except BaseException:
+        raise ValueError(radionuclide + " is not a valid member of "
+                         + data.dataset)
 
     return mass / data.masses[index] * Avogadro
 
@@ -196,8 +198,9 @@ def _number_to_activity(
 
     try:
         index = data.radionuclide_dict[radionuclide]
-    except:
-        raise ValueError(radionuclide + " is not a valid member of " + data.dataset)
+    except BaseException:
+        raise ValueError(radionuclide + " is not a valid member of "
+                         + data.dataset)
 
     return number * data.scipy_data.decay_consts[index]
 
@@ -231,8 +234,9 @@ def _number_to_mass(
 
     try:
         index = data.radionuclide_dict[radionuclide]
-    except:
-        raise ValueError(radionuclide + " is not a valid member of " + data.dataset)
+    except BaseException:
+        raise ValueError(
+            radionuclide + " is not a valid member of " + data.dataset)
 
     return number / Avogadro * data.masses[index]
 
@@ -303,7 +307,6 @@ def _input_to_number(
         Format of the input.
     data : DecayData
         Decay dataset (default is the ICRP-107 dataset).
-    
 
     Returns
     -------
@@ -400,7 +403,8 @@ def _check_dictionary(
     }
     for nuc, inp in parsed_inv_dict.items():
         if not isinstance(inp, (float, int)):
-            raise ValueError(str(inp) + " is not a valid input for " + str(nuc) + ".")
+            raise ValueError(
+                str(inp) + " is not a valid input for " + str(nuc) + ".")
 
     if input_type != "numbers":
         inv_dict = _input_to_number(parsed_inv_dict, input_type, data).copy()
@@ -472,7 +476,7 @@ class Inventory:
     Attributes
     ----------
     numbers : dict
-        Dictionary containing radionuclide strings as keys and numbers as values. Radionuclides
+        Dictionary containing nuclide string as keys and number of nuclides as values. Radionuclides
         in contents are sorted alphabetically.
     data : DecayData
         Decay dataset.
@@ -480,12 +484,12 @@ class Inventory:
     Examples
     --------
     >>> rd.Inventory({'Tc-99m': 2.3, 'I-123': 5.8})
-    Inventory: {'I-123': 399738.47946141585, 'Tc-99m': 71852.27235544211}, decay dataset: icrp107
+    Inventory activities: {'I-123': 2.3, 'Tc-99m': 5.8}, decay dataset: icrp107
     >>> H3 = rd.Radionuclide('H-3')
     >>> rd.Inventory({H3: 3.0})
-    Inventory: {'H-3': 1682678687.3382246}, decay dataset: icrp107
+    Inventory activities: {'H-3': 3.0}, decay dataset: icrp107
     >>> rd.Inventory({'U-238': 21.1, 'Co-57': 7.2}, input_type="masses")
-    Inventory: {'Co-57': 7.61542657764305e+22, 'U-238': 5.337817684684321e+22}, decay dataset: icrp107
+    Inventory activities: {'Co-57': 7.2, 'U-238': 21.1}, decay dataset: icrp107
 
     """
 
@@ -535,7 +539,7 @@ class Inventory:
 
     def numbers(self) -> Dict[str, float]:
         """
-        Returns a dictionary of radionuclides and associated numbers in the inventory.
+        Returns a dictionary containing the number of atoms of each nuclide within the inventory.
 
         Examples
         --------
@@ -548,7 +552,7 @@ class Inventory:
 
     def activities(self) -> Dict[str, float]:
         """
-        Returns a dictionary of radionuclides and associated activities in the inventory.
+        Returns a dictionary containing the activity of each nuclide within the inventory.
 
         Examples
         --------
@@ -566,7 +570,7 @@ class Inventory:
 
     def masses(self) -> Dict[str, float]:
         """
-        Returns a dictionary of radionuclides and associated masses in the inventory.
+        Returns a dictionary containing the mass of each nuclide within the inventory
 
         Examples
         --------
@@ -584,7 +588,7 @@ class Inventory:
 
     def moles(self) -> Dict[str, float]:
         """
-        Returns a dictionary of radionuclides and associated moles of material in the inventory.
+        Returns a dictionary containing the number of atoms of each nuclide within the inventory in moles.
 
         Examples
         --------
@@ -593,13 +597,14 @@ class Inventory:
 
         """
 
-        moles = {nuc: _number_to_moles(num) for nuc, num in self.contents.items()}
+        moles = {nuc: _number_to_moles(num)
+                 for nuc, num in self.contents.items()}
 
         return moles
 
     def mass_abundances(self) -> Dict[str, float]:
         """
-        Returns a dictionary of radionuclides and associated mass abundances in the inventory.
+        Returns a dictionary containing the mass fraction of each nuclide within the inventory.
 
         Examples
         --------
@@ -609,9 +614,29 @@ class Inventory:
         """
 
         total_mass = sum(self.masses().values())
-        abundances = {nuc: mass / total_mass for nuc, mass in self.masses().items()}
+        abundances = {
+            nuc: mass / total_mass for nuc,
+            mass in self.masses().items()}
 
         return abundances
+
+    def mole_fractions(self) -> Dict[str, float]:
+        """
+        Returns a dictionary containing the mole fraction of each nuclide within the inventory.
+
+        Examples
+        --------
+        >>> rd.Inventory({'Tc-99m': 2.3, 'I-123': 5.8}).mole_fractions()
+        {'I-123': 0.8476385041932588, 'Tc-99m': 0.15236149580674116}
+
+        """
+
+        total_number = sum(self.numbers().values())
+        mole_fractions = {
+            nuc: num / total_number for nuc, num in self.numbers().items()
+        }
+
+        return mole_fractions
 
     def __len__(self) -> int:
         """
@@ -626,21 +651,23 @@ class Inventory:
         input_type: str = "activity",
     ) -> None:
         """
-        Adds a dictionary of radionuclides and associated numbers to the inventory.
+        Adds a dictionary of radionuclides and associated numbers/activities/masses
+        to the inventory.
 
         Parameters
         ----------
         add_contents : dict
-            Dictionary containing radionuclide strings or Radionuclide objects as keys and
-            activities as values which are added to the Inventory.
+            Dictionary containing nuclide strings or Radionuclide objects as keys 
+            and the amount of each nuclide, as specified by input_type, as values
+            which are added to the Inventory.
         input_type : str, optional
-            Type of input, default is activities.
+            Type of input (masses, numbers, activities; activities is default)
 
         Examples
         --------
-        >>> inv = rd.Inventory({'H-3': 1.0}, "numbers")
-        >>> inv.add({'C-14': 2.0}, "numbers")
-        >>> inv.contents()
+        >>> inv = rd.Inventory({'H-3': 1.0})
+        >>> inv.add({'C-14': 2.0})
+        >>> inv.activities()
         {'C-14': 2.0, 'H-3': 1.0}
 
         """
@@ -657,28 +684,31 @@ class Inventory:
         input_type: str = "activities",
     ) -> None:
         """
-        Subtracts a dictionary of radionuclides and associated numbers from this inventory.
+        Subtracts a dictionary of radionuclides and associated numbers/activities/masses
+        from the inventory.
 
         Parameters
         ----------
         sub_contents : dict
-            Dictionary containing radionuclide strings or Radionuclide objects as keys and
-            numbers as values which are subtracted from the Inventory.
+            Dictionary containing nuclide strings or Radionuclide objects as keys 
+            and the amount of each nuclide, as specified by input_type, as values
+            which are subtracted from the Inventory.
+        input_type : str, optional
+            Type of input (masses, numbers, activities; activities is default)
 
         Examples
         --------
-        >>> inv = rd.Inventory({'C-14': 2.0, 'H-3': 1.0}, "numbers")
-        >>> inv.subtract({'H-3': 1.0}, "numbers")
-        >>> inv.contents()
+        >>> inv = rd.Inventory({'C-14': 2.0, 'H-3': 1.0})
+        >>> inv.subtract({'H-3': 1.0})
+        >>> inv.activities()
         {'C-14': 2.0, 'H-3': 0.0}
 
         """
         parsed_sub_contents: Dict[str, float] = _check_dictionary(
             sub_contents, self.data.radionuclides, input_type, self.data
         )
-        parsed_sub_contents.update(
-            (nuclide, number * -1.0) for nuclide, number in parsed_sub_contents.items()
-        )
+        parsed_sub_contents.update((nuclide, number * -1.0)
+                                   for nuclide, number in parsed_sub_contents.items())
         new_contents = _add_dictionaries(self.contents, parsed_sub_contents)
         self._change(new_contents, "numbers", False, self.data)
 
@@ -710,15 +740,14 @@ class Inventory:
                 + other.data.dataset
             )
         sub_contents = other.contents.copy()
-        sub_contents.update(
-            (nuclide, number * -1.0) for nuclide, number in sub_contents.items()
-        )
+        sub_contents.update((nuclide, number * -1.0)
+                            for nuclide, number in sub_contents.items())
         new_contents = _add_dictionaries(self.contents, sub_contents)
         return Inventory(new_contents, "numbers", False, self.data)
 
     def __mul__(self, const: float) -> "Inventory":
         """
-        Defines * operator to multiply all activities of radionuclides in an Inventory by a
+        Defines * operator to multiply all quantities of nuclides in an Inventory by a
         float or int.
         """
 
@@ -729,7 +758,7 @@ class Inventory:
 
     def __rmul__(self, const: float) -> "Inventory":
         """
-        Defines * operator to multiply all activities of radionuclides in an Inventory by a
+        Defines * operator to multiply all quantities of nuclides in an Inventory by a
         float or int.
         """
 
@@ -737,7 +766,7 @@ class Inventory:
 
     def __truediv__(self, const: float) -> "Inventory":
         """
-        Defines / operator to divide all activities of radionuclides in an Inventory by a
+        Defines / operator to divide all quantities of nuclides in an Inventory by a
         float or int.
         """
 
@@ -748,12 +777,12 @@ class Inventory:
         self, delete: Union[str, Radionuclide, List[Union[str, Radionuclide]]]
     ) -> None:
         """
-        Removes radionuclide(s) from this inventory.
+        Removes nuclide(s) from this inventory.
 
         Parameters
         ----------
         delete : str or Radionuclide or list
-            Radionuclide string, Radionuclide object or list of radionuclide strings or
+            Radionuclide string, Radionuclide object or list of nuclide strings or
             Radionuclide objects to delete from the Inventory object.
 
         Examples
@@ -767,13 +796,16 @@ class Inventory:
         {'C-14': 3.0}
 
         """
-        raise NotImplementedError("remove() takes string or list of radionuclides.")
+        raise NotImplementedError(
+            "remove() takes string or list of nuclides.")
 
     @remove.register(str)
-    def _(self, delete: str) -> Callable[[Dict[str, float], bool, DecayData], None]:
-        """Remove radionuclide string from this inventory."""
+    def _(
+            self, delete: str) -> Callable[[Dict[str, float], bool, DecayData], None]:
+        """Remove nuclide string from this inventory."""
 
-        delete = parse_radionuclide(delete, self.data.radionuclides, self.data.dataset)
+        delete = parse_radionuclide(
+            delete, self.data.radionuclides, self.data.dataset)
         new_contents = self.contents.copy()
         if delete not in new_contents:
             raise ValueError(delete + " does not exist in this inventory.")
@@ -799,16 +831,18 @@ class Inventory:
     def _(
         self, delete: List[Union[str, Radionuclide]]
     ) -> Callable[[Dict[str, float], bool, DecayData], None]:
-        """Remove list of radionuclide(s) from this inventory."""
+        """Remove list of nuclide(s) from this inventory."""
 
         delete = [
             parse_radionuclide(
-                nuc.radionuclide, self.data.radionuclides, self.data.dataset
-            )
-            if isinstance(nuc, Radionuclide)
-            else parse_radionuclide(nuc, self.data.radionuclides, self.data.dataset)
-            for nuc in delete
-        ]
+                nuc.radionuclide,
+                self.data.radionuclides,
+                self.data.dataset) if isinstance(
+                nuc,
+                Radionuclide) else parse_radionuclide(
+                nuc,
+                self.data.radionuclides,
+                self.data.dataset) for nuc in delete]
         new_contents = self.contents.copy()
         for nuc in delete:
             if nuc not in new_contents:
@@ -816,9 +850,8 @@ class Inventory:
             new_contents.pop(nuc)
         self._change(new_contents, "numbers", False, self.data)
 
-    def decay(
-        self, decay_time: float, units: str = "s", sig_fig: Union[None, int] = None
-    ) -> "Inventory":
+    def decay(self, decay_time: float, units: str = "s",
+              sig_fig: Union[None, int] = None) -> "Inventory":
         """
         Returns a new Inventory calculated from the radioactive decay of the current Inventory for
         decay_time.
@@ -859,9 +892,12 @@ class Inventory:
 
         if sig_fig is not None:
             if sig_fig < 1:
-                raise ValueError("sig_fig needs to be an integer greater than 0.")
+                raise ValueError(
+                    "sig_fig needs to be an integer greater than 0.")
             if self.data.sympy_data is None:
-                raise ValueError("No SymPy data in decay dataset " + self.data.dataset)
+                raise ValueError(
+                    "No SymPy data in decay dataset " +
+                    self.data.dataset)
             return self._decay_sympy(decay_time, units, sig_fig)
 
         decay_time = (
@@ -880,7 +916,8 @@ class Inventory:
         for radionuclide in self.contents:
             i = self.data.radionuclide_dict[radionuclide]
             vector_n0[i] = self.contents[radionuclide]
-            indices_set.update(self.data.scipy_data.matrix_c[:, i].nonzero()[0])
+            indices_set.update(
+                self.data.scipy_data.matrix_c[:, i].nonzero()[0])
         indices = list(indices_set)
 
         matrix_e = self.data.scipy_data.matrix_e.copy()
@@ -894,10 +931,9 @@ class Inventory:
             @ self.data.scipy_data.matrix_c_inv
             @ vector_n0
         )
-        vector_at = vector_nt[indices]
 
         new_contents = _sort_dictionary_alphabetically(
-            dict(zip(self.data.radionuclides[indices], vector_at))
+            dict(zip(self.data.radionuclides[indices], vector_nt))
         )
 
         return Inventory(new_contents, "numbers", False, self.data)
@@ -931,7 +967,7 @@ class Inventory:
         -------
         Inventory
             New Inventory after the radioactive decay.
-        
+
         Examples
         --------
         >>> inv_t0 = rd.Inventory({'Fm-257': 1.0})
@@ -948,7 +984,11 @@ class Inventory:
 
         return self.decay(decay_time, units, sig_fig)
 
-    def _decay_sympy(self, decay_time: float, units: str, sig_fig: int) -> "Inventory":
+    def _decay_sympy(
+            self,
+            decay_time: float,
+            units: str,
+            sig_fig: int) -> "Inventory":
         """
         Version of decay() using SymPy arbitrary-precision arithmetic.
         """
@@ -971,13 +1011,15 @@ class Inventory:
         for radionuclide in self.contents:
             i = self.data.radionuclide_dict[radionuclide]
             vector_n0[i, 0] = nsimplify(self.contents[radionuclide])
-            indices_set.update(self.data.scipy_data.matrix_c[:, i].nonzero()[0])
+            indices_set.update(
+                self.data.scipy_data.matrix_c[:, i].nonzero()[0])
         indices = list(indices_set)
 
         matrix_e = self.data.sympy_data.matrix_e.copy()
         for i in indices:
             matrix_e[i, i] = exp(
-                (-decay_time * self.data.sympy_data.decay_consts[i, 0]).evalf(sig_fig)
+                (-decay_time *
+                 self.data.sympy_data.decay_consts[i, 0]).evalf(sig_fig)
             )
 
         vector_nt = (
@@ -1047,7 +1089,8 @@ class Inventory:
 
         """
 
-        return {nuc: Radionuclide(nuc, self.data).progeny() for nuc in self.contents}
+        return {nuc: Radionuclide(nuc, self.data).progeny()
+                for nuc in self.contents}
 
     def branching_fractions(self) -> Dict[str, List[float]]:
         """
@@ -1094,9 +1137,8 @@ class Inventory:
 
         """
 
-        return {
-            nuc: Radionuclide(nuc, self.data).decay_modes() for nuc in self.contents
-        }
+        return {nuc: Radionuclide(nuc, self.data).decay_modes()
+                for nuc in self.contents}
 
     def plot(
         self,
@@ -1191,7 +1233,8 @@ class Inventory:
         else:
             if xmin == 0.0:
                 xmin = 0.1
-            time_points = np.logspace(np.log10(xmin), np.log10(xmax), num=npoints)
+            time_points = np.logspace(
+                np.log10(xmin), np.log10(xmax), num=npoints)
 
         if display == "all":
             if order == "dataset":
@@ -1202,19 +1245,21 @@ class Inventory:
                 display = self.decay(0).radionuclides
             else:
                 raise ValueError(
-                    str(order) + " is not a valid string for the order parameter."
-                )
+                    str(order) +
+                    " is not a valid string for the order parameter.")
         else:
             if isinstance(display, str):
                 display = [display]
             display = [
-                parse_radionuclide(rad, self.data.radionuclides, self.data.dataset)
+                parse_radionuclide(
+                    rad, self.data.radionuclides, self.data.dataset)
                 for rad in display
             ]
 
         acts = np.zeros(shape=(npoints, len(display)))
         for i in range(0, npoints):
-            decayed_contents = self.decay(time_points[i], xunits, sig_fig).contents
+            decayed_contents = self.decay(
+                time_points[i], xunits, sig_fig).contents
             acts[i] = [decayed_contents[rad] for rad in display]
 
         if yscale == "log" and ymin == 0.0:
@@ -1240,7 +1285,10 @@ class Inventory:
 
     def __repr__(self) -> str:
         return (
-            "Inventory: " + str(self.contents) + ", decay dataset: " + self.data.dataset
+            "Inventory activities: "
+            + str(self.activities())
+            + ", decay dataset: "
+            + self.data.dataset
         )
 
     def __eq__(self, other) -> bool:

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -683,7 +683,7 @@ class Inventory:
         """
 
         parsed_add_contents: Dict[str, float] = _check_dictionary(
-            add_contents, self.data.radionuclides, self.data.dataset, input_type
+            add_contents, self.data.radionuclides, input_type, self.data
         )
         new_contents = _add_dictionaries(self.contents, parsed_add_contents)
         self._change(new_contents, "number", False, self.data)
@@ -711,7 +711,7 @@ class Inventory:
 
         """
         parsed_sub_contents: Dict[str, float] = _check_dictionary(
-            sub_contents, self.data.radionuclides, input_type, self.data.dataset
+            sub_contents, self.data.radionuclides, input_type, self.data
         )
         parsed_sub_contents.update(
             (nuclide, number * -1.0)

--- a/radioactivedecay/inventory.py
+++ b/radioactivedecay/inventory.py
@@ -74,9 +74,7 @@ def _add_dictionaries(
 
 
 def _activity_to_number(
-    radionuclide: str,
-    activity : float,
-    data: DecayData = DEFAULTDATA
+    radionuclide: str, activity: float, data: DecayData = DEFAULTDATA
 ) -> float:
     """
     Converts activity to number of atoms.
@@ -105,19 +103,13 @@ def _activity_to_number(
     try:
         index = data.radionuclide_dict[radionuclide]
     except:
-        raise ValueError(
-            radionuclide
-            + " is not a valid member of "
-            + data.dataset
-            )
-        
-    return (activity / data.scipy_data.decay_consts[index])
+        raise ValueError(radionuclide + " is not a valid member of " + data.dataset)
+
+    return activity / data.scipy_data.decay_consts[index]
 
 
 def _mass_to_number(
-    radionuclide: str,
-    mass : float,
-    data: DecayData = DEFAULTDATA
+    radionuclide: str, mass: float, data: DecayData = DEFAULTDATA
 ) -> float:
     """
     Converts a mass to number of atoms.
@@ -146,16 +138,12 @@ def _mass_to_number(
     try:
         index = data.radionuclide_dict[radionuclide]
     except:
-        raise ValueError(
-            radionuclide
-            + " is not a valid member of "
-            + data.dataset
-            )
+        raise ValueError(radionuclide + " is not a valid member of " + data.dataset)
 
-    return (mass / data.masses[index] * Avogadro)
+    return mass / data.masses[index] * Avogadro
 
 
-def _moles_to_number(moles : float) -> float:
+def _moles_to_number(moles: float) -> float:
     """
     Converts number of moles to number of atoms.
 
@@ -180,9 +168,7 @@ def _moles_to_number(moles : float) -> float:
 
 
 def _number_to_activity(
-    radionuclide: str,
-    number : float,
-    data: DecayData = DEFAULTDATA
+    radionuclide: str, number: float, data: DecayData = DEFAULTDATA
 ) -> float:
     """
     Converts number of atoms to activity.
@@ -211,19 +197,13 @@ def _number_to_activity(
     try:
         index = data.radionuclide_dict[radionuclide]
     except:
-        raise ValueError(
-            radionuclide
-            + " is not a valid member of "
-            + data.dataset
-            )
-    
-    return (number * data.scipy_data.decay_consts[index])
+        raise ValueError(radionuclide + " is not a valid member of " + data.dataset)
+
+    return number * data.scipy_data.decay_consts[index]
 
 
 def _number_to_mass(
-    radionuclide: str,
-    number : float,
-    data: DecayData = DEFAULTDATA
+    radionuclide: str, number: float, data: DecayData = DEFAULTDATA
 ) -> float:
     """
     Converts number of atoms to mass in grams.
@@ -252,13 +232,9 @@ def _number_to_mass(
     try:
         index = data.radionuclide_dict[radionuclide]
     except:
-        raise ValueError(
-            radionuclide
-            + " is not a valid member of "
-            + data.dataset
-            )
-    
-    return (number / Avogadro * data.masses[index])
+        raise ValueError(radionuclide + " is not a valid member of " + data.dataset)
+
+    return number / Avogadro * data.masses[index]
 
 
 def _number_to_moles(number: float) -> float:
@@ -281,7 +257,7 @@ def _number_to_moles(number: float) -> float:
     0.49816172015215404
 
     """
-    
+
     return number / Avogadro
 
 
@@ -313,9 +289,7 @@ def _sort_dictionary_alphabetically(
 
 
 def _input_to_number(
-    input_inv_dict: Dict[str, float],
-    input_type : str,
-    data: DecayData = DEFAULTDATA
+    input_inv_dict: Dict[str, float], input_type: str, data: DecayData = DEFAULTDATA
 ) -> Dict[str, float]:
     """
     Converts mass, moles, or activity input inventory dictionary into number.
@@ -349,9 +323,9 @@ def _input_to_number(
     {'U-238': 5.337817684684321e+22, 'Co-57': 7.61542657764305e+22}
 
     """
-    
-    number_abundance_dict, number_dict = {}, {}
-    
+
+    number_dict = {}
+
     if input_type == "masses":
         for nuc, mass in input_inv_dict.items():
             number = _mass_to_number(nuc, mass, data)
@@ -364,14 +338,11 @@ def _input_to_number(
         converted_dict = number_dict.copy()
     elif input_type == "moles":
         for nuc, moles in input_inv_dict.items():
-            number = _moles_to_number(nuc, moles, data)
+            number = _moles_to_number(moles)
             number_dict[nuc] = number
         converted_dict = number_dict.copy()
     else:
-        raise ValueError(
-            input_type
-            + " is not a valid value input type"
-        )
+        raise ValueError(input_type + " is not a valid value input type")
 
     return converted_dict
 
@@ -380,7 +351,7 @@ def _check_dictionary(
     input_inv_dict: Dict[Union[str, Radionuclide], float],
     radionuclides: List[str],
     input_type: str = "activities",
-    data: DecayData = DEFAULTDATA
+    data: DecayData = DEFAULTDATA,
 ) -> Dict[str, float]:
     """
     Checks validity of a dictionary of radionuclides and associated numbers. Radionuclides must
@@ -429,9 +400,7 @@ def _check_dictionary(
     }
     for nuc, inp in parsed_inv_dict.items():
         if not isinstance(inp, (float, int)):
-            raise ValueError(
-                str(inp) + " is not a valid input for " + str(nuc) + "."
-            )
+            raise ValueError(str(inp) + " is not a valid input for " + str(nuc) + ".")
 
     if input_type != "numbers":
         inv_dict = _input_to_number(parsed_inv_dict, input_type, data).copy()
@@ -525,7 +494,7 @@ class Inventory:
         input: Dict[Union[str, Radionuclide], float],
         input_type: str = "activities",
         check: bool = True,
-        data: DecayData = DEFAULTDATA
+        data: DecayData = DEFAULTDATA,
     ) -> None:
 
         self._change(input, input_type, check, data)
@@ -535,7 +504,7 @@ class Inventory:
         contents: Dict[Union[str, Radionuclide], float],
         input_type: str,
         check: bool,
-        data: DecayData
+        data: DecayData,
     ) -> None:
         """
         Changes the contents and data attributes of this Inventory instance.
@@ -549,7 +518,7 @@ class Inventory:
         )
         self.data: DecayData = data
         self.input_type = input_type
-        
+
     @property
     def radionuclides(self) -> List[str]:
         """
@@ -563,7 +532,7 @@ class Inventory:
         """
 
         return list(self.contents)
-    
+
     def numbers(self) -> Dict[str, float]:
         """
         Returns a dictionary of radionuclides and associated numbers in the inventory.
@@ -589,12 +558,12 @@ class Inventory:
         """
 
         activities = {
-            nuc : _number_to_activity(nuc, num, self.data)
+            nuc: _number_to_activity(nuc, num, self.data)
             for nuc, num in self.contents.items()
         }
 
         return activities
-    
+
     def masses(self) -> Dict[str, float]:
         """
         Returns a dictionary of radionuclides and associated masses in the inventory.
@@ -607,12 +576,12 @@ class Inventory:
         """
 
         masses = {
-            nuc : _number_to_mass(nuc, num, self.data)
+            nuc: _number_to_mass(nuc, num, self.data)
             for nuc, num in self.contents.items()
         }
 
         return masses
-    
+
     def moles(self) -> Dict[str, float]:
         """
         Returns a dictionary of radionuclides and associated moles of material in the inventory.
@@ -624,13 +593,10 @@ class Inventory:
 
         """
 
-        moles = {
-            nuc : _number_to_moles(num)
-            for nuc, num in self.contents.items()
-        }
+        moles = {nuc: _number_to_moles(num) for nuc, num in self.contents.items()}
 
         return moles
-    
+
     def mass_abundances(self) -> Dict[str, float]:
         """
         Returns a dictionary of radionuclides and associated mass abundances in the inventory.
@@ -643,11 +609,8 @@ class Inventory:
         """
 
         total_mass = sum(self.masses().values())
-        abundances = {
-            nuc : mass / total_mass
-            for nuc, mass in self.masses().items()
-        }
-        
+        abundances = {nuc: mass / total_mass for nuc, mass in self.masses().items()}
+
         return abundances
 
     def __len__(self) -> int:
@@ -660,7 +623,7 @@ class Inventory:
     def add(
         self,
         add_contents: Dict[Union[str, Radionuclide], float],
-        input_type: str = "activity"
+        input_type: str = "activity",
     ) -> None:
         """
         Adds a dictionary of radionuclides and associated numbers to the inventory.
@@ -691,7 +654,7 @@ class Inventory:
     def subtract(
         self,
         sub_contents: Dict[Union[str, Radionuclide], float],
-        input_type: str = "activities"
+        input_type: str = "activities",
     ) -> None:
         """
         Subtracts a dictionary of radionuclides and associated numbers from this inventory.
@@ -714,8 +677,7 @@ class Inventory:
             sub_contents, self.data.radionuclides, input_type, self.data
         )
         parsed_sub_contents.update(
-            (nuclide, number * -1.0)
-            for nuclide, number in parsed_sub_contents.items()
+            (nuclide, number * -1.0) for nuclide, number in parsed_sub_contents.items()
         )
         new_contents = _add_dictionaries(self.contents, parsed_sub_contents)
         self._change(new_contents, "numbers", False, self.data)
@@ -749,8 +711,7 @@ class Inventory:
             )
         sub_contents = other.contents.copy()
         sub_contents.update(
-            (nuclide, number * -1.0)
-            for nuclide, number in sub_contents.items()
+            (nuclide, number * -1.0) for nuclide, number in sub_contents.items()
         )
         new_contents = _add_dictionaries(self.contents, sub_contents)
         return Inventory(new_contents, "numbers", False, self.data)
@@ -918,7 +879,7 @@ class Inventory:
         indices_set = set()
         for radionuclide in self.contents:
             i = self.data.radionuclide_dict[radionuclide]
-            vector_n0[i] = (self.contents[radionuclide])
+            vector_n0[i] = self.contents[radionuclide]
             indices_set.update(self.data.scipy_data.matrix_c[:, i].nonzero()[0])
         indices = list(indices_set)
 
@@ -1009,7 +970,7 @@ class Inventory:
         indices_set = set()
         for radionuclide in self.contents:
             i = self.data.radionuclide_dict[radionuclide]
-            vector_n0[i, 0] = (nsimplify(self.contents[radionuclide]))
+            vector_n0[i, 0] = nsimplify(self.contents[radionuclide])
             indices_set.update(self.data.scipy_data.matrix_c[:, i].nonzero()[0])
         indices = list(indices_set)
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -53,50 +53,49 @@ class Test(unittest.TestCase):
         radionuclides = ["H-3", "C-14"]
         H3 = Radionuclide("H3")
         C14 = Radionuclide("C14")
-        dataset = "test"
 
         # Dictionary parsing
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0}, radionuclides, dataset), {"H-3": 1.0}
+            _check_dictionary({"H-3": 1.0}, radionuclides, input_type="number"), {"H-3": 1.0}
         )
         self.assertEqual(
-            _check_dictionary({"H3": 1.0}, radionuclides, dataset), {"H-3": 1.0}
+            _check_dictionary({"H3": 1.0}, radionuclides, input_type="number"), {"H-3": 1.0}
         )
         self.assertEqual(
-            _check_dictionary({"3H": 1.0}, radionuclides, dataset), {"H-3": 1.0}
+            _check_dictionary({"3H": 1.0}, radionuclides, input_type="number"), {"H-3": 1.0}
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1}, radionuclides, dataset), {"H-3": 1}
+            _check_dictionary({"H-3": 1}, radionuclides, input_type="number"), {"H-3": 1}
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1}, radionuclides, dataset), {"H-3": 1.0}
+            _check_dictionary({"H-3": 1}, radionuclides, input_type="number"), {"H-3": 1.0}
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, dataset),
+            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="number"),
             {"H-3": 1.0, "C-14": 2.0},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, dataset),
+            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="number"),
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({H3: 1.0, C14: 2.0}, radionuclides, dataset),
+            _check_dictionary({H3: 1.0, C14: 2.0}, radionuclides, input_type="number"),
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, C14: 2.0}, radionuclides, dataset),
+            _check_dictionary({"H-3": 1.0, C14: 2.0}, radionuclides, input_type="number"),
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({H3: 1.0, "C-14": 2.0}, radionuclides, dataset),
+            _check_dictionary({H3: 1.0, "C-14": 2.0}, radionuclides, input_type="number"),
             {"C-14": 2.0, "H-3": 1.0},
         )
 
         # Catch incorrect arguments
         with self.assertRaises(ValueError):
-            _check_dictionary({"H-3": "1.0"}, radionuclides, dataset)
+            _check_dictionary({"H-3": "1.0"}, radionuclides, input_type="number")
         with self.assertRaises(ValueError):
-            _check_dictionary({"1.0": "H-3"}, radionuclides, dataset)
+            _check_dictionary({"1.0": "H-3"}, radionuclides, input_type="number")
 
     def test__sort_list_according_to_dataset(self):
         """
@@ -116,18 +115,18 @@ class Test(unittest.TestCase):
         Test instantiation of Inventory objects.
         """
 
-        inv = Inventory({"H-3": 1.0})
+        inv = Inventory({"H-3": 1.0}, "number")
         self.assertEqual(inv.contents, {"H-3": 1.0})
 
-        inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8})
+        inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8}, "number")
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
         Tc99m = Radionuclide("Tc-99m")
-        inv = Inventory({Tc99m: 2.3, "I-123": 5.8})
+        inv = Inventory({Tc99m: 2.3, "I-123": 5.8}, "number")
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
         I123 = Radionuclide("I-123")
-        inv = Inventory({"Tc-99m": 2.3, I123: 5.8})
+        inv = Inventory({"Tc-99m": 2.3, I123: 5.8}, "number")
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
     def test_inventory__change(self):
@@ -136,12 +135,12 @@ class Test(unittest.TestCase):
         """
 
         inv = Inventory({"H-3": 1.0})
-        inv._change({"Tc-99m": 2.3, "I-123": 5.8}, True, DEFAULTDATA)
+        inv._change({"Tc-99m": 2.3, "I-123": 5.8}, "number", True, DEFAULTDATA)
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
         Tc99m = Radionuclide("Tc-99m")
         inv = Inventory({"H-3": 1.0})
-        inv._change({Tc99m: 2.3, "I-123": 5.8}, True, DEFAULTDATA)
+        inv._change({Tc99m: 2.3, "I-123": 5.8}, "number", True, DEFAULTDATA)
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
     def test_inventory_radionuclides(self):
@@ -160,9 +159,9 @@ class Test(unittest.TestCase):
         """
 
         inv = Inventory({"H-3": 1})
-        self.assertEqual(inv.activities, [1.0])
+        self.assertEqual(inv.activities(), {"H-3": 1})
         inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8})
-        self.assertEqual(inv.activities, [5.8, 2.3])
+        self.assertEqual(inv.activities(), {"I-123": 5.8, "Tc-99m": 2.3})
 
     def test_inventory___len__(self):
         """
@@ -179,16 +178,16 @@ class Test(unittest.TestCase):
         Test Inventory add() method to append to an inventory.
         """
 
-        inv = Inventory({"H-3": 1})
-        inv.add({"C-14": 3.0, "K-40": 4.0})
+        inv = Inventory({"H-3": 1}, "number")
+        inv.add({"C-14": 3.0, "K-40": 4.0}, "number")
         self.assertEqual(inv.contents, {"C-14": 3.0, "H-3": 1.0, "K-40": 4.0})
-        inv.add({"H-3": 3.0})
+        inv.add({"H-3": 3.0}, "number")
         self.assertEqual(inv.contents, {"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
 
-        inv = Inventory({"H-3": 1})
-        inv.add({Radionuclide("C-14"): 3.0, "K-40": 4.0})
+        inv = Inventory({"H-3": 1}, "number")
+        inv.add({Radionuclide("C-14"): 3.0, "K-40": 4.0}, "number")
         self.assertEqual(inv.contents, {"C-14": 3.0, "H-3": 1.0, "K-40": 4.0})
-        inv.add({Radionuclide("H-3"): 3.0})
+        inv.add({Radionuclide("H-3"): 3.0}, "number")
         self.assertEqual(inv.contents, {"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
 
     def test_inventory_subtract(self):
@@ -196,27 +195,27 @@ class Test(unittest.TestCase):
         Test Inventory subtract() method to take away a dictionary from an inventory.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
-        inv.subtract({"C-14": 3.0, "K-40": 4.0})
-        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0})
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
+        inv.subtract({"C-14": 3.0, "K-40": 4.0}, "number")
+        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "number")
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
-        inv.subtract({"C-14": 3.0, Radionuclide("K-40"): 4.0})
-        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0})
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
+        inv.subtract({"C-14": 3.0, Radionuclide("K-40"): 4.0}, "number")
+        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "number")
 
     def test_inventory___add__(self):
         """
         Test operator to add two inventory objects together.
         """
 
-        inv1 = Inventory({"H-3": 1.0})
-        inv2 = Inventory({"C-14": 1.0, "H-3": 4.0})
+        inv1 = Inventory({"H-3": 1.0}, "number")
+        inv2 = Inventory({"C-14": 1.0, "H-3": 4.0}, "number")
         inv = inv1 + inv2
-        self.assertEqual(inv.contents, {"C-14": 1.0, "H-3": 5.0})
+        self.assertEqual(inv.contents, {"C-14": 1.0, "H-3": 5.0}, "number")
 
         temp_data = copy.deepcopy(DEFAULTDATA)
         temp_data.dataset = "icrp107_"
-        inv3 = Inventory({"H-3": 2.0}, data=temp_data)
+        inv3 = Inventory({"H-3": 2.0}, "number", data=temp_data)
         with self.assertRaises(ValueError):
             inv = inv1 + inv3
 
@@ -225,14 +224,14 @@ class Test(unittest.TestCase):
         Test operator to subtract one inventory object from another.
         """
 
-        inv1 = Inventory({"H-3": 1.0})
-        inv2 = Inventory({"C-14": 1.0, "H-3": 4.0})
+        inv1 = Inventory({"H-3": 1.0}, "number")
+        inv2 = Inventory({"C-14": 1.0, "H-3": 4.0}, "number")
         inv = inv2 - inv1
         self.assertEqual(inv.contents, {"C-14": 1.0, "H-3": 3.0})
 
         temp_data = copy.deepcopy(DEFAULTDATA)
         temp_data.dataset = "icrp107_"
-        inv3 = Inventory({"H-3": 2.0}, data=temp_data)
+        inv3 = Inventory({"H-3": 2.0}, "number", data=temp_data)
         with self.assertRaises(ValueError):
             inv = inv1 - inv3
 
@@ -241,7 +240,7 @@ class Test(unittest.TestCase):
         Test operator to multiply activities in inventory by constant.
         """
 
-        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0})
+        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "number")
         inv = inv * 2
         self.assertEqual(inv.contents, {"Cs-137": 2.0, "Sr-90": 2.0})
 
@@ -250,7 +249,7 @@ class Test(unittest.TestCase):
         Test operator to right multiply constant by activities in inventory.
         """
 
-        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0})
+        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "number")
         inv = 2 * inv
         self.assertEqual(inv.contents, {"Cs-137": 2.0, "Sr-90": 2.0})
 
@@ -259,7 +258,7 @@ class Test(unittest.TestCase):
         Test operator to multiply activities in inventory by constant.
         """
 
-        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0})
+        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "number")
         inv = inv / 2
         self.assertEqual(inv.contents, {"Cs-137": 0.5, "Sr-90": 0.5})
 
@@ -268,7 +267,7 @@ class Test(unittest.TestCase):
         Test operator to remove radionuclides from an inventory.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
         with self.assertRaises(NotImplementedError):
             inv.remove(1.0)
 
@@ -277,7 +276,7 @@ class Test(unittest.TestCase):
         Test operator to remove one radionuclide from an inventory using a radionuclide string.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
         inv.remove("H-3")
         self.assertEqual(inv.contents, {"C-14": 3.0, "K-40": 4.0})
 
@@ -289,7 +288,7 @@ class Test(unittest.TestCase):
         Test operator to remove one radionuclide from an inventory using a ``Radionuclide`` object.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
         inv.remove(Radionuclide("H-3"))
         self.assertEqual(inv.contents, {"C-14": 3.0, "K-40": 4.0})
 
@@ -301,14 +300,14 @@ class Test(unittest.TestCase):
         Test operator to remove list of radionuclides from an inventory.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
         inv.remove(["H-3", "C-14"])
         self.assertEqual(inv.contents, {"K-40": 4.0})
 
         with self.assertRaises(ValueError):
             inv.remove(["Be-10", "C-14"])
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
         inv.remove(["H-3", Radionuclide("C-14")])
         self.assertEqual(inv.contents, {"K-40": 4.0})
 
@@ -317,11 +316,11 @@ class Test(unittest.TestCase):
         Test Inventory decay() calculations.
         """
 
-        inv = Inventory({"H-3": 10.0})
-        self.assertEqual(inv.decay(12.32, "y").contents, {"H-3": 5.0, "He-3": 0.0})
-        inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8})
+        inv = Inventory({"H-3": 10.0}, "activity")
+        self.assertEqual(inv.decay(12.32, "y").activities(), {"H-3": 5.0, "He-3": 0.0})
+        inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8}, "activity")
         self.assertEqual(
-            inv.decay(20.0, "h").contents,
+            inv.decay(20.0, "h").activities(),
             {
                 "I-123": 2.040459244534774,
                 "Ru-99": 0.0,
@@ -332,9 +331,9 @@ class Test(unittest.TestCase):
                 "Te-123m": 7.721174031572363e-07,
             },
         )
-        inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005})
+        inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005}, "activity")
         self.assertEqual(
-            inv.decay(1e9, "y").contents,
+            inv.decay(1e9, "y").activities(),
             {
                 "Ac-227": 0.2690006281740556,
                 "At-218": 0.017002868638497183,
@@ -380,7 +379,7 @@ class Test(unittest.TestCase):
         with self.assertRaises(ValueError):
             inv.decay(1e9, "y", sig_fig=0)
         data = DecayData("icrp107", load_sympy=False)
-        inv = Inventory({"H-3": 10.0}, data=data)
+        inv = Inventory({"H-3": 10.0}, "number", data=data)
         with self.assertRaises(ValueError):
             inv.decay(1e9, "y", sig_fig=320)
 
@@ -388,9 +387,9 @@ class Test(unittest.TestCase):
         """
         Test Inventory decay_high_precision() calculations.
         """
-        inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005})
+        inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005}, "activity")
         self.assertEqual(
-            inv.decay_high_precision(1e9, "y").contents,
+            inv.decay_high_precision(1e9, "y").activities(),
             {
                 "Ac-227": 0.26900062817405557,
                 "At-218": 0.01700286863849718,
@@ -437,7 +436,7 @@ class Test(unittest.TestCase):
         Test method to fetch half-lives of radionuclides in the Inventory.
         """
 
-        inv = Inventory({"C-14": 1.0, "H-3": 2.0})
+        inv = Inventory({"C-14": 1.0, "H-3": 2.0}, "number")
         self.assertEqual(inv.half_lives("y"), {"C-14": 5700.0, "H-3": 12.32})
         self.assertEqual(
             inv.half_lives("readable"), {"C-14": "5.70 ky", "H-3": "12.32 y"}
@@ -448,7 +447,7 @@ class Test(unittest.TestCase):
         Test spelling variation of half_lives() method.
         """
 
-        inv = Inventory({"C-14": 1.0, "H-3": 2.0})
+        inv = Inventory({"C-14": 1.0, "H-3": 2.0}, "number")
         self.assertEqual(inv.half_life("s"), inv.half_lives("s"))
         self.assertEqual(inv.half_life("y"), inv.half_lives("y"))
         self.assertEqual(inv.half_life("readable"), inv.half_lives("readable"))
@@ -458,7 +457,7 @@ class Test(unittest.TestCase):
         Test method to fetch progeny of radionuclides in the Inventory.
         """
 
-        inv = Inventory({"C-14": 1.0, "K-40": 2.0})
+        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "number")
         self.assertEqual(inv.progeny(), {"C-14": ["N-14"], "K-40": ["Ca-40", "Ar-40"]})
 
     def test_inventory_branching_fractions(self):
@@ -466,7 +465,7 @@ class Test(unittest.TestCase):
         Test method to fetch branching fractions of radionuclides in the Inventory.
         """
 
-        inv = Inventory({"C-14": 1.0, "K-40": 2.0})
+        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "number")
         self.assertEqual(
             inv.branching_fractions(), {"C-14": [1.0], "K-40": [0.8914, 0.1086]}
         )
@@ -476,7 +475,7 @@ class Test(unittest.TestCase):
         Test method to fetch decay modes of radionuclides in the Inventory.
         """
 
-        inv = Inventory({"C-14": 1.0, "K-40": 2.0})
+        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "number")
         self.assertEqual(
             inv.decay_modes(),
             {"C-14": ["\u03b2-"], "K-40": ["\u03b2-", "\u03b2+ \u0026 EC"]},
@@ -488,7 +487,7 @@ class Test(unittest.TestCase):
         Test method to create decay plots.
         """
 
-        inv = Inventory({"C-14": 1.0, "K-40": 2.0})
+        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "number")
         _, ax = inv.plot(105, "ky")
         self.assertEqual(ax.get_xscale(), "linear")
         self.assertEqual(ax.get_yscale(), "linear")
@@ -536,7 +535,7 @@ class Test(unittest.TestCase):
         Test Inventory representations.
         """
 
-        inv = Inventory({"H-3": 10.0})
+        inv = Inventory({"H-3": 10.0}, "number")
         self.assertEqual(
             inv.__repr__(), "Inventory: {'H-3': 10.0}, decay dataset: icrp107"
         )
@@ -550,8 +549,8 @@ class Test(unittest.TestCase):
         inv2 = Inventory({"H3": 10.0})
         self.assertEqual(inv1, inv2)
 
-        data = DecayData("icrp107")
-        inv2 = Inventory({"H-3": 10.0}, data)
+        data = DecayData("icrp107", load_sympy=True)
+        inv2 = Inventory({"H-3": 10.0}, data=data)
         self.assertEqual(inv1, inv2)
 
     def test_inventory___ne__(self):

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -56,26 +56,35 @@ class Test(unittest.TestCase):
 
         # Dictionary parsing
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0}, radionuclides, input_type="numbers"), {"H-3": 1.0}
+            _check_dictionary({"H-3": 1.0}, radionuclides, input_type="numbers"),
+            {"H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({"H3": 1.0}, radionuclides, input_type="numbers"), {"H-3": 1.0}
+            _check_dictionary({"H3": 1.0}, radionuclides, input_type="numbers"),
+            {"H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({"3H": 1.0}, radionuclides, input_type="numbers"), {"H-3": 1.0}
+            _check_dictionary({"3H": 1.0}, radionuclides, input_type="numbers"),
+            {"H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1}, radionuclides, input_type="numbers"), {"H-3": 1}
+            _check_dictionary({"H-3": 1}, radionuclides, input_type="numbers"),
+            {"H-3": 1},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1}, radionuclides, input_type="numbers"), {"H-3": 1.0}
+            _check_dictionary({"H-3": 1}, radionuclides, input_type="numbers"),
+            {"H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"),
+            _check_dictionary(
+                {"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"
+            ),
             {"H-3": 1.0, "C-14": 2.0},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"),
+            _check_dictionary(
+                {"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"
+            ),
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
@@ -83,11 +92,15 @@ class Test(unittest.TestCase):
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, C14: 2.0}, radionuclides, input_type="numbers"),
+            _check_dictionary(
+                {"H-3": 1.0, C14: 2.0}, radionuclides, input_type="numbers"
+            ),
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({H3: 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"),
+            _check_dictionary(
+                {H3: 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"
+            ),
             {"C-14": 2.0, "H-3": 1.0},
         )
 
@@ -197,11 +210,15 @@ class Test(unittest.TestCase):
 
         inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
         inv.subtract({"C-14": 3.0, "K-40": 4.0}, "numbers")
-        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "numbers")
+        self.assertEqual(
+            inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "numbers"
+        )
 
         inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
         inv.subtract({"C-14": 3.0, Radionuclide("K-40"): 4.0}, "numbers")
-        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "numbers")
+        self.assertEqual(
+            inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "numbers"
+        )
 
     def test_inventory___add__(self):
         """

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -56,46 +56,46 @@ class Test(unittest.TestCase):
 
         # Dictionary parsing
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0}, radionuclides, input_type="number"), {"H-3": 1.0}
+            _check_dictionary({"H-3": 1.0}, radionuclides, input_type="numbers"), {"H-3": 1.0}
         )
         self.assertEqual(
-            _check_dictionary({"H3": 1.0}, radionuclides, input_type="number"), {"H-3": 1.0}
+            _check_dictionary({"H3": 1.0}, radionuclides, input_type="numbers"), {"H-3": 1.0}
         )
         self.assertEqual(
-            _check_dictionary({"3H": 1.0}, radionuclides, input_type="number"), {"H-3": 1.0}
+            _check_dictionary({"3H": 1.0}, radionuclides, input_type="numbers"), {"H-3": 1.0}
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1}, radionuclides, input_type="number"), {"H-3": 1}
+            _check_dictionary({"H-3": 1}, radionuclides, input_type="numbers"), {"H-3": 1}
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1}, radionuclides, input_type="number"), {"H-3": 1.0}
+            _check_dictionary({"H-3": 1}, radionuclides, input_type="numbers"), {"H-3": 1.0}
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="number"),
+            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"),
             {"H-3": 1.0, "C-14": 2.0},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="number"),
+            _check_dictionary({"H-3": 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"),
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({H3: 1.0, C14: 2.0}, radionuclides, input_type="number"),
+            _check_dictionary({H3: 1.0, C14: 2.0}, radionuclides, input_type="numbers"),
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({"H-3": 1.0, C14: 2.0}, radionuclides, input_type="number"),
+            _check_dictionary({"H-3": 1.0, C14: 2.0}, radionuclides, input_type="numbers"),
             {"C-14": 2.0, "H-3": 1.0},
         )
         self.assertEqual(
-            _check_dictionary({H3: 1.0, "C-14": 2.0}, radionuclides, input_type="number"),
+            _check_dictionary({H3: 1.0, "C-14": 2.0}, radionuclides, input_type="numbers"),
             {"C-14": 2.0, "H-3": 1.0},
         )
 
         # Catch incorrect arguments
         with self.assertRaises(ValueError):
-            _check_dictionary({"H-3": "1.0"}, radionuclides, input_type="number")
+            _check_dictionary({"H-3": "1.0"}, radionuclides, input_type="numbers")
         with self.assertRaises(ValueError):
-            _check_dictionary({"1.0": "H-3"}, radionuclides, input_type="number")
+            _check_dictionary({"1.0": "H-3"}, radionuclides, input_type="numbers")
 
     def test__sort_list_according_to_dataset(self):
         """
@@ -115,18 +115,18 @@ class Test(unittest.TestCase):
         Test instantiation of Inventory objects.
         """
 
-        inv = Inventory({"H-3": 1.0}, "number")
+        inv = Inventory({"H-3": 1.0}, "numbers")
         self.assertEqual(inv.contents, {"H-3": 1.0})
 
-        inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8}, "number")
+        inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8}, "numbers")
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
         Tc99m = Radionuclide("Tc-99m")
-        inv = Inventory({Tc99m: 2.3, "I-123": 5.8}, "number")
+        inv = Inventory({Tc99m: 2.3, "I-123": 5.8}, "numbers")
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
         I123 = Radionuclide("I-123")
-        inv = Inventory({"Tc-99m": 2.3, I123: 5.8}, "number")
+        inv = Inventory({"Tc-99m": 2.3, I123: 5.8}, "numbers")
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
     def test_inventory__change(self):
@@ -135,12 +135,12 @@ class Test(unittest.TestCase):
         """
 
         inv = Inventory({"H-3": 1.0})
-        inv._change({"Tc-99m": 2.3, "I-123": 5.8}, "number", True, DEFAULTDATA)
+        inv._change({"Tc-99m": 2.3, "I-123": 5.8}, "numbers", True, DEFAULTDATA)
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
         Tc99m = Radionuclide("Tc-99m")
         inv = Inventory({"H-3": 1.0})
-        inv._change({Tc99m: 2.3, "I-123": 5.8}, "number", True, DEFAULTDATA)
+        inv._change({Tc99m: 2.3, "I-123": 5.8}, "numbers", True, DEFAULTDATA)
         self.assertEqual(inv.contents, {"Tc-99m": 2.3, "I-123": 5.8})
 
     def test_inventory_radionuclides(self):
@@ -178,16 +178,16 @@ class Test(unittest.TestCase):
         Test Inventory add() method to append to an inventory.
         """
 
-        inv = Inventory({"H-3": 1}, "number")
-        inv.add({"C-14": 3.0, "K-40": 4.0}, "number")
+        inv = Inventory({"H-3": 1}, "numbers")
+        inv.add({"C-14": 3.0, "K-40": 4.0}, "numbers")
         self.assertEqual(inv.contents, {"C-14": 3.0, "H-3": 1.0, "K-40": 4.0})
-        inv.add({"H-3": 3.0}, "number")
+        inv.add({"H-3": 3.0}, "numbers")
         self.assertEqual(inv.contents, {"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
 
-        inv = Inventory({"H-3": 1}, "number")
-        inv.add({Radionuclide("C-14"): 3.0, "K-40": 4.0}, "number")
+        inv = Inventory({"H-3": 1}, "numbers")
+        inv.add({Radionuclide("C-14"): 3.0, "K-40": 4.0}, "numbers")
         self.assertEqual(inv.contents, {"C-14": 3.0, "H-3": 1.0, "K-40": 4.0})
-        inv.add({Radionuclide("H-3"): 3.0}, "number")
+        inv.add({Radionuclide("H-3"): 3.0}, "numbers")
         self.assertEqual(inv.contents, {"C-14": 3.0, "H-3": 4.0, "K-40": 4.0})
 
     def test_inventory_subtract(self):
@@ -195,27 +195,27 @@ class Test(unittest.TestCase):
         Test Inventory subtract() method to take away a dictionary from an inventory.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
-        inv.subtract({"C-14": 3.0, "K-40": 4.0}, "number")
-        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "number")
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
+        inv.subtract({"C-14": 3.0, "K-40": 4.0}, "numbers")
+        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "numbers")
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
-        inv.subtract({"C-14": 3.0, Radionuclide("K-40"): 4.0}, "number")
-        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "number")
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
+        inv.subtract({"C-14": 3.0, Radionuclide("K-40"): 4.0}, "numbers")
+        self.assertEqual(inv.contents, {"C-14": 0.0, "H-3": 4.0, "K-40": 0.0}, "numbers")
 
     def test_inventory___add__(self):
         """
         Test operator to add two inventory objects together.
         """
 
-        inv1 = Inventory({"H-3": 1.0}, "number")
-        inv2 = Inventory({"C-14": 1.0, "H-3": 4.0}, "number")
+        inv1 = Inventory({"H-3": 1.0}, "numbers")
+        inv2 = Inventory({"C-14": 1.0, "H-3": 4.0}, "numbers")
         inv = inv1 + inv2
-        self.assertEqual(inv.contents, {"C-14": 1.0, "H-3": 5.0}, "number")
+        self.assertEqual(inv.contents, {"C-14": 1.0, "H-3": 5.0}, "numbers")
 
         temp_data = copy.deepcopy(DEFAULTDATA)
         temp_data.dataset = "icrp107_"
-        inv3 = Inventory({"H-3": 2.0}, "number", data=temp_data)
+        inv3 = Inventory({"H-3": 2.0}, "numbers", data=temp_data)
         with self.assertRaises(ValueError):
             inv = inv1 + inv3
 
@@ -224,14 +224,14 @@ class Test(unittest.TestCase):
         Test operator to subtract one inventory object from another.
         """
 
-        inv1 = Inventory({"H-3": 1.0}, "number")
-        inv2 = Inventory({"C-14": 1.0, "H-3": 4.0}, "number")
+        inv1 = Inventory({"H-3": 1.0}, "numbers")
+        inv2 = Inventory({"C-14": 1.0, "H-3": 4.0}, "numbers")
         inv = inv2 - inv1
         self.assertEqual(inv.contents, {"C-14": 1.0, "H-3": 3.0})
 
         temp_data = copy.deepcopy(DEFAULTDATA)
         temp_data.dataset = "icrp107_"
-        inv3 = Inventory({"H-3": 2.0}, "number", data=temp_data)
+        inv3 = Inventory({"H-3": 2.0}, "numbers", data=temp_data)
         with self.assertRaises(ValueError):
             inv = inv1 - inv3
 
@@ -240,7 +240,7 @@ class Test(unittest.TestCase):
         Test operator to multiply activities in inventory by constant.
         """
 
-        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "number")
+        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "numbers")
         inv = inv * 2
         self.assertEqual(inv.contents, {"Cs-137": 2.0, "Sr-90": 2.0})
 
@@ -249,7 +249,7 @@ class Test(unittest.TestCase):
         Test operator to right multiply constant by activities in inventory.
         """
 
-        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "number")
+        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "numbers")
         inv = 2 * inv
         self.assertEqual(inv.contents, {"Cs-137": 2.0, "Sr-90": 2.0})
 
@@ -258,7 +258,7 @@ class Test(unittest.TestCase):
         Test operator to multiply activities in inventory by constant.
         """
 
-        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "number")
+        inv = Inventory({"Sr-90": 1.0, "Cs-137": 1.0}, "numbers")
         inv = inv / 2
         self.assertEqual(inv.contents, {"Cs-137": 0.5, "Sr-90": 0.5})
 
@@ -267,7 +267,7 @@ class Test(unittest.TestCase):
         Test operator to remove radionuclides from an inventory.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
         with self.assertRaises(NotImplementedError):
             inv.remove(1.0)
 
@@ -276,7 +276,7 @@ class Test(unittest.TestCase):
         Test operator to remove one radionuclide from an inventory using a radionuclide string.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
         inv.remove("H-3")
         self.assertEqual(inv.contents, {"C-14": 3.0, "K-40": 4.0})
 
@@ -288,7 +288,7 @@ class Test(unittest.TestCase):
         Test operator to remove one radionuclide from an inventory using a ``Radionuclide`` object.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
         inv.remove(Radionuclide("H-3"))
         self.assertEqual(inv.contents, {"C-14": 3.0, "K-40": 4.0})
 
@@ -300,14 +300,14 @@ class Test(unittest.TestCase):
         Test operator to remove list of radionuclides from an inventory.
         """
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
         inv.remove(["H-3", "C-14"])
         self.assertEqual(inv.contents, {"K-40": 4.0})
 
         with self.assertRaises(ValueError):
             inv.remove(["Be-10", "C-14"])
 
-        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "number")
+        inv = Inventory({"C-14": 3.0, "H-3": 4.0, "K-40": 4.0}, "numbers")
         inv.remove(["H-3", Radionuclide("C-14")])
         self.assertEqual(inv.contents, {"K-40": 4.0})
 
@@ -316,9 +316,9 @@ class Test(unittest.TestCase):
         Test Inventory decay() calculations.
         """
 
-        inv = Inventory({"H-3": 10.0}, "activity")
+        inv = Inventory({"H-3": 10.0}, "activities")
         self.assertEqual(inv.decay(12.32, "y").activities(), {"H-3": 5.0, "He-3": 0.0})
-        inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8}, "activity")
+        inv = Inventory({"Tc-99m": 2.3, "I-123": 5.8}, "activities")
         self.assertEqual(
             inv.decay(20.0, "h").activities(),
             {
@@ -331,7 +331,7 @@ class Test(unittest.TestCase):
                 "Te-123m": 7.721174031572363e-07,
             },
         )
-        inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005}, "activity")
+        inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005}, "activities")
         self.assertEqual(
             inv.decay(1e9, "y").activities(),
             {
@@ -379,7 +379,7 @@ class Test(unittest.TestCase):
         with self.assertRaises(ValueError):
             inv.decay(1e9, "y", sig_fig=0)
         data = DecayData("icrp107", load_sympy=False)
-        inv = Inventory({"H-3": 10.0}, "number", data=data)
+        inv = Inventory({"H-3": 10.0}, "numbers", data=data)
         with self.assertRaises(ValueError):
             inv.decay(1e9, "y", sig_fig=320)
 
@@ -387,7 +387,7 @@ class Test(unittest.TestCase):
         """
         Test Inventory decay_high_precision() calculations.
         """
-        inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005}, "activity")
+        inv = Inventory({"U-238": 99.274, "U-235": 0.720, "U-234": 0.005}, "activities")
         self.assertEqual(
             inv.decay_high_precision(1e9, "y").activities(),
             {
@@ -436,7 +436,7 @@ class Test(unittest.TestCase):
         Test method to fetch half-lives of radionuclides in the Inventory.
         """
 
-        inv = Inventory({"C-14": 1.0, "H-3": 2.0}, "number")
+        inv = Inventory({"C-14": 1.0, "H-3": 2.0}, "numbers")
         self.assertEqual(inv.half_lives("y"), {"C-14": 5700.0, "H-3": 12.32})
         self.assertEqual(
             inv.half_lives("readable"), {"C-14": "5.70 ky", "H-3": "12.32 y"}
@@ -447,7 +447,7 @@ class Test(unittest.TestCase):
         Test spelling variation of half_lives() method.
         """
 
-        inv = Inventory({"C-14": 1.0, "H-3": 2.0}, "number")
+        inv = Inventory({"C-14": 1.0, "H-3": 2.0}, "numbers")
         self.assertEqual(inv.half_life("s"), inv.half_lives("s"))
         self.assertEqual(inv.half_life("y"), inv.half_lives("y"))
         self.assertEqual(inv.half_life("readable"), inv.half_lives("readable"))
@@ -457,7 +457,7 @@ class Test(unittest.TestCase):
         Test method to fetch progeny of radionuclides in the Inventory.
         """
 
-        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "number")
+        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "numbers")
         self.assertEqual(inv.progeny(), {"C-14": ["N-14"], "K-40": ["Ca-40", "Ar-40"]})
 
     def test_inventory_branching_fractions(self):
@@ -465,7 +465,7 @@ class Test(unittest.TestCase):
         Test method to fetch branching fractions of radionuclides in the Inventory.
         """
 
-        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "number")
+        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "numbers")
         self.assertEqual(
             inv.branching_fractions(), {"C-14": [1.0], "K-40": [0.8914, 0.1086]}
         )
@@ -475,7 +475,7 @@ class Test(unittest.TestCase):
         Test method to fetch decay modes of radionuclides in the Inventory.
         """
 
-        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "number")
+        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "numbers")
         self.assertEqual(
             inv.decay_modes(),
             {"C-14": ["\u03b2-"], "K-40": ["\u03b2-", "\u03b2+ \u0026 EC"]},
@@ -487,7 +487,7 @@ class Test(unittest.TestCase):
         Test method to create decay plots.
         """
 
-        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "number")
+        inv = Inventory({"C-14": 1.0, "K-40": 2.0}, "numbers")
         _, ax = inv.plot(105, "ky")
         self.assertEqual(ax.get_xscale(), "linear")
         self.assertEqual(ax.get_yscale(), "linear")
@@ -535,7 +535,7 @@ class Test(unittest.TestCase):
         Test Inventory representations.
         """
 
-        inv = Inventory({"H-3": 10.0}, "number")
+        inv = Inventory({"H-3": 10.0}, "numbers")
         self.assertEqual(
             inv.__repr__(), "Inventory: {'H-3': 10.0}, decay dataset: icrp107"
         )


### PR DESCRIPTION
This PR aims to modify the `Inventory` class' contents attribute and IO to allow for activities, masses, or number of nuclides to be input and output in `radioactivedecay`. The `Inventory.contents` attribute is changed to hold number of atoms of each nuclide. Furthermore, the `input_type` parameter is added, allowing the user to input number of atoms, mass in grams, or activity of each nuclide in the inventory. Functions are added to convert mass and activity to number and vice versa, and the `Inventory._check_dictionary()` method is modified to convert inputs to number for the `contents` attribute. Finally, `Inventory` methods are added to output activities, mass, mass abundance, and number, and the `DecayData` class is modified to hold atomic mass data.